### PR TITLE
Fix vendor filters to include newly added vendors

### DIFF
--- a/3d_quote.html
+++ b/3d_quote.html
@@ -711,14 +711,16 @@
 
     // ===== 设置区：厂商过滤 & 新增厂商 =====
     function rebuildMaterialsVendorFilter() {
-      const materials = getMaterialsFromTable();
       const select = document.getElementById("materialsVendorFilter");
       const prev = currentMaterialsVendor || select.value;
 
-      let vendors = [...new Set(materials.map(m => m.vendor))];
-      if (vendors.length === 0) {
-        vendors = ["未分类"];
-      }
+      // 读取表格中的所有厂商（即便当前行还没填写材料名称，也要保留厂商）
+      const rows = document.querySelectorAll("#materialsTableBody tr");
+      let vendors = [...new Set(Array.from(rows).map(row => {
+        const vInput = row.querySelector(".mat-vendor");
+        return (vInput?.value || "").trim() || "未分类";
+      }))];
+      if (vendors.length === 0) vendors = ["未分类"];
 
       select.innerHTML = "";
       vendors.forEach(v => {
@@ -732,7 +734,6 @@
       select.value = currentMaterialsVendor;
 
       // 只显示当前厂商的行
-      const rows = document.querySelectorAll("#materialsTableBody tr");
       rows.forEach(row => {
         const vInput = row.querySelector(".mat-vendor");
         const v = (vInput.value || "").trim() || "未分类";
@@ -741,14 +742,16 @@
     }
 
     function rebuildMachinesVendorFilter() {
-      const machines = getMachinesFromTable();
       const select = document.getElementById("machinesVendorFilter");
       const prev = currentMachinesVendor || select.value;
 
-      let vendors = [...new Set(machines.map(m => m.vendor))];
-      if (vendors.length === 0) {
-        vendors = ["未分类"];
-      }
+      // 读取表格中所有设备行的厂商（即便未填写名称也要保留），保证新增厂商立即可选
+      const rows = document.querySelectorAll("#machinesTableBody tr");
+      let vendors = [...new Set(Array.from(rows).map(row => {
+        const vInput = row.querySelector(".mac-vendor");
+        return (vInput?.value || "").trim() || "未分类";
+      }))];
+      if (vendors.length === 0) vendors = ["未分类"];
 
       select.innerHTML = "";
       vendors.forEach(v => {
@@ -758,15 +761,14 @@
         select.appendChild(opt);
       });
 
-      currentMachinesVendor = vendors.includes(prev) ? prev : vendors[0];
-      select.value = currentMachinesVendor;
+        currentMachinesVendor = vendors.includes(prev) ? prev : vendors[0];
+        select.value = currentMachinesVendor;
 
-      const rows = document.querySelectorAll("#machinesTableBody tr");
-      rows.forEach(row => {
-        const vInput = row.querySelector(".mac-vendor");
-        const v = (vInput.value || "").trim() || "未分类";
-        row.style.display = v === currentMachinesVendor ? "" : "none";
-      });
+        rows.forEach(row => {
+          const vInput = row.querySelector(".mac-vendor");
+          const v = (vInput.value || "").trim() || "未分类";
+          row.style.display = v === currentMachinesVendor ? "" : "none";
+        });
     }
 
     document.getElementById("materialsVendorFilter").addEventListener("change", () => {


### PR DESCRIPTION
## Summary
- ensure material and machine vendor filters include entries even before items are fully filled out
- keep newly added vendors visible immediately after creation so options update correctly

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f3e10b7188329b5d2a17c831d286a)