### PR TITLE
Add self-service account tools and process cost tables

### DIFF
--- a/3d_quote.html
+++ b/3d_quote.html
@@ -288,8 +288,8 @@
       gap: 8px;
     }
     .mat-price-inputs input {
-      width: 160px;
-      flex-shrink: 0;
+      width: 100%;
+      min-width: 0;
     }
     .inline-config {
       display: grid;
@@ -395,6 +395,33 @@
         <button type="button" id="userLoginBtn">登录</button>
       </div>
       <div class="hint">不同账户对应不同权限：管理员登录后可管理配置、报价记录与用户；普通账号可进行报价计算。</div>
+    </div>
+
+    <div class="login-panel" id="accountPanel" style="display:none;">
+      <h3>账户设置</h3>
+      <div class="login-row">
+        <div>
+          <label for="selfNewUsername">新用户名</label>
+          <input id="selfNewUsername" type="text" placeholder="输入新的用户名" />
+        </div>
+        <div>
+          <label for="selfUsernamePassword">当前密码</label>
+          <input id="selfUsernamePassword" type="password" placeholder="验证当前密码" />
+        </div>
+        <button type="button" id="selfChangeUsernameBtn">修改用户名</button>
+      </div>
+      <div class="login-row" style="margin-top:10px;">
+        <div>
+          <label for="selfOldPassword">当前密码</label>
+          <input id="selfOldPassword" type="password" placeholder="请输入当前密码" />
+        </div>
+        <div>
+          <label for="selfNewPassword">新密码</label>
+          <input id="selfNewPassword" type="password" placeholder="请输入新密码" />
+        </div>
+        <button type="button" id="selfChangePasswordBtn">修改密码</button>
+      </div>
+      <div class="hint">以上操作面向当前登录的账户，修改后将自动退出登录。</div>
     </div>
 
     <div id="appContent" style="display:none;">
@@ -586,7 +613,6 @@
       <h3>
         全局参数
         <div>
-          <button type="button" class="mini-btn" id="changePasswordBtn">修改管理员密码</button>
           <button type="button" class="mini-btn" id="saveSettingsBtn">保存设置到服务器</button>
         </div>
       </h3>
@@ -627,6 +653,20 @@
           <input id="configOverheadPerMachine" type="number" step="0.1" min="0" />
         </div>
       </div>
+      <h4>按工艺的成本参数</h4>
+      <div class="table-wrapper">
+        <table>
+          <thead>
+            <tr>
+              <th style="width:24%;">工艺</th>
+              <th style="width:24%;">人工成本（元/小时）</th>
+              <th style="width:24%;">每人负责设备数</th>
+              <th style="width:28%;">杂项成本（元/台·小时）</th>
+            </tr>
+          </thead>
+          <tbody id="processCostTableBody"></tbody>
+        </table>
+      </div>
 
       <!-- 后处理设置 -->
       <h3 style="display:flex;justify-content:space-between;align-items:center;">
@@ -658,6 +698,7 @@
       <!-- 材料设置 -->
       <h3 style="display:flex;justify-content:space-between;align-items:center;">
         材料设置
+        <button type="button" class="mini-btn" id="saveSettingsBtnMaterials">保存设置到服务器</button>
       </h3>
       <div class="vendor-filter">
         <label>按工艺筛选：</label>
@@ -704,6 +745,7 @@
       <!-- 设备设置 -->
       <h3 style="display:flex;justify-content:space-between;align-items:center;">
         设备设置
+        <button type="button" class="mini-btn" id="saveSettingsBtnMachines">保存设置到服务器</button>
       </h3>
 
       <div class="vendor-filter">
@@ -756,6 +798,9 @@
     <div class="section admin-sub-section" id="userManagementSection">
       <h3>用户管理</h3>
       <small>仅管理员可见：新增普通用户或管理员，重置密码、启用/禁用账号，并配置报价记录权限。</small>
+      <div style="margin:8px 0;">
+        <button type="button" class="mini-btn" id="changePasswordBtn">修改管理员密码</button>
+      </div>
       <div class="inline-config">
         <div>
           <label for="newUserName">用户名</label>
@@ -832,6 +877,12 @@
       laborHourlyCost: 0.5,           // 操作人工成本 元/小时
       machinesPerOperator: 1,         // 每人看几台设备
       overheadHourlyPerMachine: 0,    // 杂项成本 元/台·小时
+      processCosts: {
+        FDM_3D_PRINT: { laborHourlyCost: 0.5, machinesPerOperator: 1, overheadHourlyPerMachine: 0 },
+        RESIN_3D_PRINT: { laborHourlyCost: 0.6, machinesPerOperator: 1, overheadHourlyPerMachine: 0 },
+        CNC_MILLING: { laborHourlyCost: 1, machinesPerOperator: 1, overheadHourlyPerMachine: 0 },
+        CO2_LASER_ENGRAVE_CUT: { laborHourlyCost: 0.6, machinesPerOperator: 1, overheadHourlyPerMachine: 0 }
+      },
 
       materials: [
         { vendor: "通用", name: "PLA", pricePerKg: 120, processType: "FDM_3D_PRINT", pricingMode: "WEIGHT" },
@@ -975,6 +1026,55 @@
       });
       const allowed = [PROCESS_FILTER_ALL, ...PROCESS_TYPES.map(pt => pt.value)];
       selectEl.value = allowed.includes(value) ? value : PROCESS_FILTER_ALL;
+    }
+
+    function getProcessCostConfig(processType) {
+      const costs = runtimeConfig.processCosts || {};
+      const fallback = costs[processType] || {};
+      return {
+        laborHourlyCost: fallback.laborHourlyCost ?? runtimeConfig.laborHourlyCost ?? CLIENT_DEFAULTS.laborHourlyCost,
+        machinesPerOperator: fallback.machinesPerOperator ?? runtimeConfig.machinesPerOperator ?? CLIENT_DEFAULTS.machinesPerOperator,
+        overheadHourlyPerMachine: fallback.overheadHourlyPerMachine ?? runtimeConfig.overheadHourlyPerMachine ?? CLIENT_DEFAULTS.overheadHourlyPerMachine,
+      };
+    }
+
+    function renderProcessCostRows() {
+      const tbody = document.getElementById("processCostTableBody");
+      if (!tbody) return;
+      tbody.innerHTML = "";
+      PROCESS_TYPES.forEach(pt => {
+        const row = document.createElement("tr");
+        const conf = getProcessCostConfig(pt.value);
+        row.innerHTML = `
+          <td>${pt.label}</td>
+          <td><input type="number" class="process-cost-labor" data-process="${pt.value}" step="0.1" min="0" value="${conf.laborHourlyCost ?? ""}" /></td>
+          <td><input type="number" class="process-cost-mpo" data-process="${pt.value}" step="0.1" min="0" value="${conf.machinesPerOperator ?? ""}" /></td>
+          <td><input type="number" class="process-cost-oh" data-process="${pt.value}" step="0.1" min="0" value="${conf.overheadHourlyPerMachine ?? ""}" /></td>
+        `;
+        tbody.appendChild(row);
+      });
+    }
+
+    function getProcessCostsFromTable() {
+      const rows = document.querySelectorAll("#processCostTableBody tr");
+      const result = {};
+      for (const row of rows) {
+        const process = row.querySelector(".process-cost-labor")?.getAttribute("data-process");
+        if (!process) continue;
+        const labor = parseFloat(row.querySelector(".process-cost-labor")?.value);
+        const mpo = parseFloat(row.querySelector(".process-cost-mpo")?.value);
+        const oh = parseFloat(row.querySelector(".process-cost-oh")?.value);
+        if ([labor, mpo, oh].some(v => isNaN(v) || v < 0) || mpo === 0) {
+          alert("请为每个工艺填写有效的人工成本、设备数量和杂项成本（>=0，设备数量>0）");
+          return null;
+        }
+        result[process] = {
+          laborHourlyCost: labor,
+          machinesPerOperator: mpo,
+          overheadHourlyPerMachine: oh,
+        };
+      }
+      return result;
     }
 
     function getCurrentProcessType() {
@@ -1811,6 +1911,12 @@
       document.getElementById("configLaborHourly").value = (runtimeConfig.laborHourlyCost ?? CLIENT_DEFAULTS.laborHourlyCost).toString();
       document.getElementById("configMachinesPerOperator").value = (runtimeConfig.machinesPerOperator ?? CLIENT_DEFAULTS.machinesPerOperator).toString();
       document.getElementById("configOverheadPerMachine").value = (runtimeConfig.overheadHourlyPerMachine ?? CLIENT_DEFAULTS.overheadHourlyPerMachine).toString();
+      renderProcessCostRows();
+
+      const customMarginInput = document.getElementById("customMargin");
+      if (customMarginInput && customMarginInput.value === "") {
+        customMarginInput.value = (runtimeConfig.defaultProfitMargin * 100).toFixed(0);
+      }
 
           }
 
@@ -1835,6 +1941,9 @@
         runtimeConfig.laborHourlyCost = data.laborHourlyCost ?? CLIENT_DEFAULTS.laborHourlyCost;
         runtimeConfig.machinesPerOperator =  data.machinesPerOperator ?? CLIENT_DEFAULTS.machinesPerOperator;
         runtimeConfig.overheadHourlyPerMachine = data.overheadHourlyPerMachine ?? CLIENT_DEFAULTS.overheadHourlyPerMachine;
+        runtimeConfig.processCosts = data.processCosts && Object.keys(data.processCosts).length
+          ? data.processCosts
+          : CLIENT_DEFAULTS.processCosts;
         runtimeConfig.postProcessRules = Array.isArray(data.postProcessRules) && data.postProcessRules.length
           ? data.postProcessRules.map(r => ({
               ...r,
@@ -1881,6 +1990,7 @@
 
     function updateAuthUI() {
       const loginPanel = document.getElementById("loginPanel");
+      const accountPanel = document.getElementById("accountPanel");
       const appContent = document.getElementById("appContent");
       const statusEl = document.getElementById("userStatus");
       const logoutBtn = document.getElementById("userLogoutBtn");
@@ -1895,6 +2005,7 @@
 
       const authed = isAuthenticated();
       if (loginPanel) loginPanel.style.display = authed ? "none" : "";
+      if (accountPanel) accountPanel.style.display = authed ? "" : "none";
       if (appContent) appContent.style.display = authed ? "" : "none";
       if (logoutBtn) logoutBtn.style.display = authed ? "" : "none";
 
@@ -2451,6 +2562,8 @@
 
     document.getElementById("userLoginBtn").addEventListener("click", userLoginFlow);
     document.getElementById("userLogoutBtn").addEventListener("click", logoutFlow);
+    document.getElementById("selfChangePasswordBtn").addEventListener("click", selfChangePassword);
+    document.getElementById("selfChangeUsernameBtn").addEventListener("click", selfChangeUsername);
 
     // ===== 保存设置 & 修改密码 =====
     async function saveSettingsToServer() {
@@ -2525,6 +2638,9 @@
         return;
       }
 
+      const processCosts = getProcessCostsFromTable();
+      if (!processCosts) return;
+
       const payload = {
         materials,
         machines,
@@ -2535,6 +2651,7 @@
         laborHourlyCost,
         machinesPerOperator,
         overheadHourlyPerMachine,
+        processCosts,
         postProcessRules
       };
 
@@ -2566,10 +2683,63 @@
         runtimeConfig.materials = saved.materials;
         runtimeConfig.machines = saved.machines;
         runtimeConfig.postProcessRules = saved.postProcessRules;
+        runtimeConfig.processCosts = saved.processCosts || runtimeConfig.processCosts;
         rebuildPostProcessOptions();
         alert("设置已保存到服务器。");
       } catch (e) {
         alert("保存设置失败：" + e.message);
+      }
+    }
+
+    async function selfChangePassword() {
+      if (!isAuthenticated()) {
+        alert("请先登录。");
+        return;
+      }
+      const oldPwd = document.getElementById("selfOldPassword").value;
+      const newPwd = document.getElementById("selfNewPassword").value;
+      if (!oldPwd || !newPwd) {
+        alert("请填写当前密码和新密码。");
+        return;
+      }
+      try {
+        const resp = await fetch(`${API_BASE}/account/change-password`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json", ...authHeaders() },
+          body: JSON.stringify({ oldPassword: oldPwd, newPassword: newPwd })
+        });
+        const data = await resp.json().catch(() => ({}));
+        if (!resp.ok) throw new Error(data.detail || "修改失败");
+        alert("密码已更新，请重新登录。");
+        await logoutFlow();
+      } catch (e) {
+        alert(e.message || "修改失败");
+      }
+    }
+
+    async function selfChangeUsername() {
+      if (!isAuthenticated()) {
+        alert("请先登录。");
+        return;
+      }
+      const newName = document.getElementById("selfNewUsername").value.trim();
+      const password = document.getElementById("selfUsernamePassword").value;
+      if (!newName || !password) {
+        alert("请填写新用户名和当前密码。");
+        return;
+      }
+      try {
+        const resp = await fetch(`${API_BASE}/account/change-username`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json", ...authHeaders() },
+          body: JSON.stringify({ newUsername: newName, password })
+        });
+        const data = await resp.json().catch(() => ({}));
+        if (!resp.ok) throw new Error(data.detail || "修改失败");
+        alert("用户名已更新，请使用新用户名重新登录。");
+        await logoutFlow();
+      } catch (e) {
+        alert(e.message || "修改失败");
       }
     }
 
@@ -2608,6 +2778,8 @@
 
     document.getElementById("saveSettingsBtn").addEventListener("click", saveSettingsToServer);
     document.getElementById("changePasswordBtn").addEventListener("click", changeAdminPassword);
+    document.getElementById("saveSettingsBtnMaterials").addEventListener("click", saveSettingsToServer);
+    document.getElementById("saveSettingsBtnMachines").addEventListener("click", saveSettingsToServer);
     document.getElementById("addMaterialBtn").addEventListener("click", () => {
       const vendor = currentMaterialsVendor || "未分类";
       appendMaterialRow(vendor, "", "", getCurrentProcessType(), "WEIGHT", "");
@@ -2728,12 +2900,16 @@
         ? (parseFloat(customMinInput) || 0)
         : runtimeConfig.defaultMinPricePerPart;
 
+      const processCosts = getProcessCostConfig(processType);
       const materialCostPerPart = material.pricingMode === "VOLUME"
         ? ((volume / 1000000) * (material.pricePerCubicMeter || 0))
         : ((weight / 1000) * (material.pricePerKg || 0));
-      const machineCostPerPart = totalHours * machine.hourlyRate;
+      const operatorHourly = (processCosts.laborHourlyCost || 0) / (processCosts.machinesPerOperator || 1);
+      const overheadHourly = processCosts.overheadHourlyPerMachine || 0;
+      const electricityHourly = (machine.powerW ? (machine.powerW / 1000) * (runtimeConfig.electricityPrice || 0) : 0);
+      const machineCostPerPart = totalHours * (machine.hourlyRate + operatorHourly + overheadHourly + electricityHourly);
       const totalPostMinutes = (post.baseMinutes || 0) + (post.minutesPerGram || 0) * weight;
-      const postLaborCost = (runtimeConfig.laborHourlyCost || 0) * totalPostMinutes / 60;
+      const postLaborCost = (processCosts.laborHourlyCost || 0) * totalPostMinutes / 60;
       const postMaterialCost = (post.extraMaterialCostPerGram || 0) * weight;
       const postMultiplier = post.costMultiplier || 1;
       const postCostPerPart = (postLaborCost + postMaterialCost) * postMultiplier;

--- a/3d_quote.html
+++ b/3d_quote.html
@@ -272,7 +272,7 @@
     }
     td input {
       width: 100%;
-      padding: 5px 6px;
+      padding: 7px 9px;
       font-size: 13px;
       border-radius: 6px;
       border: 1px solid #d0d0d5;
@@ -289,7 +289,7 @@
     }
     .mat-price-inputs input {
       width: 100%;
-      min-width: 0;
+      min-width: 120px;
     }
     .inline-config {
       display: grid;
@@ -397,38 +397,12 @@
       <div class="hint">不同账户对应不同权限：管理员登录后可管理配置、报价记录与用户；普通账号可进行报价计算。</div>
     </div>
 
-    <div class="login-panel" id="accountPanel" style="display:none;">
-      <h3>账户设置</h3>
-      <div class="login-row">
-        <div>
-          <label for="selfNewUsername">新用户名</label>
-          <input id="selfNewUsername" type="text" placeholder="输入新的用户名" />
-        </div>
-        <div>
-          <label for="selfUsernamePassword">当前密码</label>
-          <input id="selfUsernamePassword" type="password" placeholder="验证当前密码" />
-        </div>
-        <button type="button" id="selfChangeUsernameBtn">修改用户名</button>
-      </div>
-      <div class="login-row" style="margin-top:10px;">
-        <div>
-          <label for="selfOldPassword">当前密码</label>
-          <input id="selfOldPassword" type="password" placeholder="请输入当前密码" />
-        </div>
-        <div>
-          <label for="selfNewPassword">新密码</label>
-          <input id="selfNewPassword" type="password" placeholder="请输入新密码" />
-        </div>
-        <button type="button" id="selfChangePasswordBtn">修改密码</button>
-      </div>
-      <div class="hint">以上操作面向当前登录的账户，修改后将自动退出登录。</div>
-    </div>
-
     <div id="appContent" style="display:none;">
 
     <div class="page-tabs main-tabs">
       <button class="page-tab active" data-main="quoteMain">报价工作台</button>
       <button class="page-tab" data-main="recordsMain" style="display:none;">报价记录</button>
+      <button class="page-tab" data-main="accountMain" style="display:none;">账户设置</button>
       <button class="page-tab" data-main="adminMain" data-require-admin="true">管理中心</button>
     </div>
 
@@ -550,6 +524,37 @@
     </div> <!-- /quoteSection -->
     </div> <!-- /quoteMain -->
 
+    <div class="main-section" id="accountMain">
+      <div class="section active" id="accountSection">
+        <div class="login-panel" style="margin:0 0 10px;">
+          <h3>账户设置</h3>
+          <div class="login-row">
+            <div>
+              <label for="selfNewUsername">新用户名</label>
+              <input id="selfNewUsername" type="text" placeholder="输入新的用户名" />
+            </div>
+            <div>
+              <label for="selfUsernamePassword">当前密码</label>
+              <input id="selfUsernamePassword" type="password" placeholder="验证当前密码" />
+            </div>
+            <button type="button" id="selfChangeUsernameBtn">修改用户名</button>
+          </div>
+          <div class="login-row" style="margin-top:10px;">
+            <div>
+              <label for="selfOldPassword">当前密码</label>
+              <input id="selfOldPassword" type="password" placeholder="请输入当前密码" />
+            </div>
+            <div>
+              <label for="selfNewPassword">新密码</label>
+              <input id="selfNewPassword" type="password" placeholder="请输入新密码" />
+            </div>
+            <button type="button" id="selfChangePasswordBtn">修改密码</button>
+          </div>
+          <div class="hint">仅当前登录账户可见，修改后会自动退出登录以重新验证。</div>
+        </div>
+      </div>
+    </div>
+
     <div class="main-section" id="recordsMain">
       <div class="section active" id="recordsSection">
         <h3>报价记录</h3>
@@ -630,29 +635,12 @@
           <label for="configSetupFee">开机/调机费（元/订单）</label>
           <input id="configSetupFee" type="number" step="0.1" min="0" />
         </div>
-      </div>
-
-            <!-- 全局成本设置（新增） -->
-      <h3>全局成本设置</h3>
-      <small>用于计算设备小时成本：折旧 + 电费 + 人工 + 杂项。</small>
-      <div class="inline-config">
         <div>
           <label for="configElectricityPrice">电价（元 / kWh）</label>
           <input id="configElectricityPrice" type="number" step="0.01" min="0" />
         </div>
-        <div>
-          <label for="configLaborHourly">操作人工成本（元 / 小时）</label>
-          <input id="configLaborHourly" type="number" step="0.1" min="0" />
-        </div>
-        <div>
-          <label for="configMachinesPerOperator">每名操作员负责设备数量（台）</label>
-          <input id="configMachinesPerOperator" type="number" step="1" min="1" />
-        </div>
-        <div>
-          <label for="configOverheadPerMachine">杂项成本（元 / 台·小时）</label>
-          <input id="configOverheadPerMachine" type="number" step="0.1" min="0" />
-        </div>
       </div>
+
       <h4>按工艺的成本参数</h4>
       <div class="table-wrapper">
         <table>
@@ -757,8 +745,8 @@
         <button type="button" class="mini-btn" id="addMachineVendorBtn">添加厂商</button>
       </div>
       <small>
-        单位：元 / 小时。可以填写设备价格和折旧年限，点击“算”自动计算小时成本：<br />
-        简单公式：小时成本 ≈ 设备价格 ÷（年限 × 12 × 每月工作小时）。如需包含电费 / 人工等，可在算出的基础上手动微调。
+        单位：元 / 小时。请填写设备折旧/租赁成本，人工、电费、杂项会根据工艺成本参数和电价自动累加，避免重复计算。<br />
+        填写设备价格、折旧年限和每月工时后，点击“算”自动计算折旧小时成本。
       </small>
       <div class="table-wrapper">
         <table>
@@ -1029,12 +1017,26 @@
     }
 
     function getProcessCostConfig(processType) {
+      const laborInput = document.querySelector(`.process-cost-labor[data-process="${processType}"]`);
+      const mpoInput = document.querySelector(`.process-cost-mpo[data-process="${processType}"]`);
+      const ohInput = document.querySelector(`.process-cost-oh[data-process="${processType}"]`);
+      if (laborInput && mpoInput && ohInput) {
+        const labor = parseFloat(laborInput.value);
+        const mpo = parseFloat(mpoInput.value);
+        const oh = parseFloat(ohInput.value);
+        return {
+          laborHourlyCost: isNaN(labor) ? 0 : labor,
+          machinesPerOperator: isNaN(mpo) || mpo <= 0 ? 1 : mpo,
+          overheadHourlyPerMachine: isNaN(oh) ? 0 : oh,
+        };
+      }
+
       const costs = runtimeConfig.processCosts || {};
-      const fallback = costs[processType] || {};
+      const fallback = costs[processType] || CLIENT_DEFAULTS.processCosts?.[processType] || {};
       return {
-        laborHourlyCost: fallback.laborHourlyCost ?? runtimeConfig.laborHourlyCost ?? CLIENT_DEFAULTS.laborHourlyCost,
-        machinesPerOperator: fallback.machinesPerOperator ?? runtimeConfig.machinesPerOperator ?? CLIENT_DEFAULTS.machinesPerOperator,
-        overheadHourlyPerMachine: fallback.overheadHourlyPerMachine ?? runtimeConfig.overheadHourlyPerMachine ?? CLIENT_DEFAULTS.overheadHourlyPerMachine,
+        laborHourlyCost: fallback.laborHourlyCost ?? 0,
+        machinesPerOperator: fallback.machinesPerOperator ?? 1,
+        overheadHourlyPerMachine: fallback.overheadHourlyPerMachine ?? 0,
       };
     }
 
@@ -1291,18 +1293,14 @@
       const monthInput  = tr.querySelector(".mac-monthly");
       const powerInput  = tr.querySelector(".mac-power");
       const rateInput   = tr.querySelector(".mac-rate");
+      const processValue = tr.querySelector(".mac-process")?.value;
 
       const price  = parseFloat(priceInput.value);
       const life   = parseFloat(lifeInput.value);
       const monthH = parseFloat(monthInput.value);
       const power  = parseFloat(powerInput.value);
 
-      // 全局成本参数
       const elecPrice = parseFloat(document.getElementById("configElectricityPrice").value) || 0;
-      const laborCost = parseFloat(document.getElementById("configLaborHourly").value) || 0;
-      let machinesPerOp = parseFloat(document.getElementById("configMachinesPerOperator").value);
-      if (isNaN(machinesPerOp) || machinesPerOp <= 0) machinesPerOp = 1;
-      const overhead = parseFloat(document.getElementById("configOverheadPerMachine").value) || 0;
 
       if (
         isNaN(price) || price <= 0 ||
@@ -1317,13 +1315,16 @@
 
       const totalHours = life * 12 * monthH;
       const depreciation = price / totalHours;                 // 折旧
+      const electricity = (!isNaN(power) && power > 0) ? (power / 1000) * elecPrice : 0;
 
-      const elec = (!isNaN(power) && power > 0)
-        ? (power / 1000) * elecPrice                          // 功率 * 电价
-        : 0;
+      const rate  = depreciation;    // 设备折旧/租赁小时成本，人工/电费/杂项按工艺配置单独计入
 
-      const labor = laborCost / machinesPerOp;                 // 人工成本/台
-      const rate  = depreciation + elec + labor + overhead;    // 总小时成本
+      const processHint = processValue ? getProcessCostConfig(processValue) : null;
+      if (!silent && processHint) {
+        const labor = (processHint.laborHourlyCost || 0) / (processHint.machinesPerOperator || 1);
+        const msg = `已按折旧计算小时成本：¥${rate.toFixed(1)}，运行电费另加约 ¥${electricity.toFixed(2)} /小时，人工/杂项按工艺设置单独计入。`;
+        console.info(msg, labor >= 0 ? `（人工: ¥${labor.toFixed(2)}/台·时）` : "");
+      }
 
       rateInput.value = rate.toFixed(1);
     }
@@ -1908,9 +1909,6 @@
       document.getElementById("configMinPrice").value = runtimeConfig.defaultMinPricePerPart.toString();
       document.getElementById("configSetupFee").value = runtimeConfig.setupFee.toString();
       document.getElementById("configElectricityPrice").value = (runtimeConfig.electricityPrice ?? CLIENT_DEFAULTS.electricityPrice).toString();
-      document.getElementById("configLaborHourly").value = (runtimeConfig.laborHourlyCost ?? CLIENT_DEFAULTS.laborHourlyCost).toString();
-      document.getElementById("configMachinesPerOperator").value = (runtimeConfig.machinesPerOperator ?? CLIENT_DEFAULTS.machinesPerOperator).toString();
-      document.getElementById("configOverheadPerMachine").value = (runtimeConfig.overheadHourlyPerMachine ?? CLIENT_DEFAULTS.overheadHourlyPerMachine).toString();
       renderProcessCostRows();
 
       const customMarginInput = document.getElementById("customMargin");
@@ -1938,9 +1936,6 @@
           processType: m.processType ?? null
         }));
         runtimeConfig.electricityPrice = data.electricityPrice ?? CLIENT_DEFAULTS.electricityPrice;
-        runtimeConfig.laborHourlyCost = data.laborHourlyCost ?? CLIENT_DEFAULTS.laborHourlyCost;
-        runtimeConfig.machinesPerOperator =  data.machinesPerOperator ?? CLIENT_DEFAULTS.machinesPerOperator;
-        runtimeConfig.overheadHourlyPerMachine = data.overheadHourlyPerMachine ?? CLIENT_DEFAULTS.overheadHourlyPerMachine;
         runtimeConfig.processCosts = data.processCosts && Object.keys(data.processCosts).length
           ? data.processCosts
           : CLIENT_DEFAULTS.processCosts;
@@ -1990,13 +1985,14 @@
 
     function updateAuthUI() {
       const loginPanel = document.getElementById("loginPanel");
-      const accountPanel = document.getElementById("accountPanel");
       const appContent = document.getElementById("appContent");
       const statusEl = document.getElementById("userStatus");
       const logoutBtn = document.getElementById("userLogoutBtn");
       const adminTab = document.querySelector('.main-tabs .page-tab[data-main="adminMain"]');
       const adminMain = document.getElementById("adminMain");
       const recordsTab = document.querySelector('.main-tabs .page-tab[data-main="recordsMain"]');
+      const accountTab = document.querySelector('.main-tabs .page-tab[data-main="accountMain"]');
+      const accountMain = document.getElementById("accountMain");
       const recordsMain = document.getElementById("recordsMain");
       const recordVisibilitySelect = document.getElementById("recordVisibilitySelect");
       const recordVisibilityWrap = recordVisibilitySelect?.closest("div");
@@ -2005,7 +2001,6 @@
 
       const authed = isAuthenticated();
       if (loginPanel) loginPanel.style.display = authed ? "none" : "";
-      if (accountPanel) accountPanel.style.display = authed ? "" : "none";
       if (appContent) appContent.style.display = authed ? "" : "none";
       if (logoutBtn) logoutBtn.style.display = authed ? "" : "none";
 
@@ -2016,6 +2011,7 @@
       }
 
       if (adminTab) adminTab.style.display = isAdmin ? "" : "none";
+      if (accountTab) accountTab.style.display = authed ? "" : "none";
       const canSeeRecordsTab = authed && (isAdmin || canViewRecords);
       if (recordsTab) recordsTab.style.display = canSeeRecordsTab ? "" : "none";
       if (!isAdmin && adminTab?.classList.contains("active")) {
@@ -2024,11 +2020,17 @@
       if ((!authed || !canSeeRecordsTab) && recordsTab?.classList.contains("active")) {
         setMainTab(document.querySelector('.main-tabs .page-tab[data-main="quoteMain"]'));
       }
+      if (!authed && accountTab?.classList.contains("active")) {
+        setMainTab(document.querySelector('.main-tabs .page-tab[data-main="quoteMain"]'));
+      }
       if (adminMain) {
         adminMain.style.display = isAdmin ? "" : "none";
       }
       if (recordsMain) {
         recordsMain.style.display = canSeeRecordsTab ? "" : "none";
+      }
+      if (accountMain) {
+        accountMain.style.display = authed ? "" : "none";
       }
 
       if (recordVisibilitySelect) {
@@ -2593,41 +2595,11 @@
       let setupFee = parseFloat(document.getElementById("configSetupFee").value);
       if (isNaN(setupFee) || setupFee < 0) setupFee = 0;
 
-      /* ===== 新增：全局成本参数 + 简单前端校验 ===== */
-
-      // 1. 电价（元/kWh）
       const eleInput = document.getElementById("configElectricityPrice");
       let electricityPrice = parseFloat(eleInput?.value);
       if (isNaN(electricityPrice) || electricityPrice < 0) {
         alert("电价（元/kWh）请输入 0 或以上的数字");
         eleInput && eleInput.focus();
-        return;
-      }
-
-      // 2. 操作人工成本（元/小时）
-      const laborInput = document.getElementById("configLaborHourly");
-      let laborHourlyCost = parseFloat(laborInput?.value);
-      if (isNaN(laborHourlyCost) || laborHourlyCost < 0) {
-        alert("操作人工成本（元/小时）请输入 0 或以上的数字");
-        laborInput && laborInput.focus();
-        return;
-      }
-
-      // 3. 每人负责设备数量（台）
-      const mpoInput = document.getElementById("configMachinesPerOperator");
-      let machinesPerOperator = parseFloat(mpoInput?.value);
-      if (isNaN(machinesPerOperator) || machinesPerOperator <= 0) {
-        alert("每人负责设备数量请输入大于 0 的数字");
-        mpoInput && mpoInput.focus();
-        return;
-      }
-
-      // 4. 杂项成本（元/台·小时）
-      const ohInput = document.getElementById("configOverheadPerMachine");
-      let overheadHourlyPerMachine = parseFloat(ohInput?.value);
-      if (isNaN(overheadHourlyPerMachine) || overheadHourlyPerMachine < 0) {
-        alert("杂项成本（元/台·小时）请输入 0 或以上的数字");
-        ohInput && ohInput.focus();
         return;
       }
 
@@ -2641,6 +2613,9 @@
       const processCosts = getProcessCostsFromTable();
       if (!processCosts) return;
 
+      const firstProcessKey = Object.keys(processCosts)[0];
+      const fallbackProcessCost = firstProcessKey ? processCosts[firstProcessKey] : { laborHourlyCost: 0, machinesPerOperator: 1, overheadHourlyPerMachine: 0 };
+
       const payload = {
         materials,
         machines,
@@ -2648,9 +2623,9 @@
         defaultMinPricePerPart: minPrice,
         setupFee: setupFee,
         electricityPrice,
-        laborHourlyCost,
-        machinesPerOperator,
-        overheadHourlyPerMachine,
+        laborHourlyCost: fallbackProcessCost.laborHourlyCost,
+        machinesPerOperator: fallbackProcessCost.machinesPerOperator,
+        overheadHourlyPerMachine: fallbackProcessCost.overheadHourlyPerMachine,
         processCosts,
         postProcessRules
       };
@@ -3064,6 +3039,10 @@
               alert("当前账号无查看报价记录的权限，请联系管理员开启。");
               return;
             }
+          }
+          if (btn.dataset.main === "accountMain" && !isAuthenticated()) {
+            alert("请先登录后再进行账户设置。");
+            return;
           }
           setMainTab(btn);
         });

--- a/3d_quote.html
+++ b/3d_quote.html
@@ -199,26 +199,72 @@
       background: #d1d5db;
     }
 
+    .materials-table {
+      border: 1px solid #e5e7eb;
+      border-radius: 12px;
+      background: #fff;
+      padding: 12px;
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+    }
     .material-row {
       display: grid;
-      grid-template-columns: 1.2fr 1.5fr 2fr 1.5fr 1.2fr 0.8fr auto;
-      column-gap: 8px;
+      grid-template-columns: 1.2fr 1.5fr 2fr 1.5fr 1.3fr 0.9fr auto;
+      column-gap: 12px;
+      row-gap: 6px;
       align-items: center;
-      margin-bottom: 8px;
+      padding: 10px 12px;
+      border: 1px solid #eef2f7;
+      border-radius: 10px;
+      background: #f9fafb;
+      box-sizing: border-box;
+    }
+    #materialsTableBody {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+    .material-row.material-header {
+      background: transparent;
+      border: none;
+      padding: 0 6px 2px;
+      font-size: 14px;
+      font-weight: 600;
+      color: #4b5563;
+      margin: 0;
+    }
+    .material-row.material-header > div {
+      display: flex;
+      align-items: center;
+      line-height: 1.3;
+    }
+    .material-cell {
+      display: flex;
+      align-items: center;
+      min-width: 0;
+      width: 100%;
+      gap: 8px;
     }
     .material-row select,
     .material-row input,
     .material-row button,
-    .material-row .mini-btn {
+    .material-row .mini-btn,
+    .material-row .unit-text {
       height: 36px;
       line-height: 36px;
       box-sizing: border-box;
       font-size: 14px;
-      padding: 0 8px;
+    }
+    .material-row select,
+    .material-row input {
+      width: 100%;
+      padding: 0 10px;
     }
     .material-row .mini-btn {
-      border-radius: 6px;
+      border-radius: 8px;
       padding: 0 12px;
+      font-weight: 500;
     }
     .material-row .unit-label,
     .material-row .unit-text,
@@ -228,31 +274,18 @@
       line-height: 18px;
       color: #555;
     }
-    .material-row .unit-label,
-    .material-row .unit-text {
-      display: flex;
-      align-items: center;
-      height: 36px;
-    }
-    .material-header {
-      display: grid;
-      grid-template-columns: 1.2fr 1.5fr 2fr 1.5fr 1.2fr 0.8fr auto;
-      column-gap: 8px;
-      align-items: center;
-      margin-bottom: 4px;
-      font-size: 14px;
-      font-weight: 500;
-      color: #555;
-    }
     .material-price-cell {
-      display: flex;
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) auto auto;
+      column-gap: 10px;
       align-items: center;
-      gap: 8px;
+      min-width: 0;
     }
     .material-price-wrap {
       display: flex;
       flex-direction: column;
       gap: 2px;
+      min-width: 0;
     }
     .material-price-wrap .mat-price-volume,
     .material-price-wrap .mat-price-weight {
@@ -262,7 +295,7 @@
       line-height: 36px;
       font-size: 14px;
       box-sizing: border-box;
-      padding: 0 8px;
+      padding: 0 10px;
     }
     .material-price-wrap .mat-price-volume[style*="display:none"] {
       height: 0;
@@ -273,10 +306,12 @@
     .material-price-hint {
       margin-top: 0;
       color: #888;
+      min-height: 18px;
     }
     .material-price-cell .unit-text.mat-unit {
       font-size: 14px;
       line-height: 36px;
+      white-space: nowrap;
     }
     .material-price-cell .mini-btn.mat-delete {
       height: 36px;
@@ -787,15 +822,15 @@
         <button type="button" class="mini-btn" id="addMaterialVendorBtn">添加厂商</button>
       </div>
       <small>按计价模式填写单价：重量（元/kg）或体积（元/m³），内容会同步到上方下拉框。</small>
-      <div class="table-wrapper">
+      <div class="table-wrapper materials-table">
         <div class="material-row material-header">
-          <div>厂商</div>
-          <div>工艺</div>
-          <div>材料名称</div>
-          <div>计价模式</div>
-          <div>单价</div>
-          <div class="unit-text">单位</div>
-          <div>操作</div>
+          <div class="material-cell">厂商</div>
+          <div class="material-cell">工艺</div>
+          <div class="material-cell">材料名称</div>
+          <div class="material-cell">计价模式</div>
+          <div class="material-cell">单价</div>
+          <div class="material-cell unit-text">单位</div>
+          <div class="material-cell">操作</div>
         </div>
         <div id="materialsTableBody"></div>
       </div>
@@ -1339,14 +1374,16 @@
       const row = document.createElement("div");
       row.className = "material-row";
       row.innerHTML = `
-        <input type="text" class="mat-vendor" value="${vendor}">
-        <select class="mat-process"></select>
-        <input type="text" class="mat-name" value="${name}">
-        <select class="mat-pricing">
-          <option value="WEIGHT">按重量（元/kg）</option>
-          <option value="VOLUME">按体积（元/m³）</option>
-        </select>
-        <div class="material-price-cell">
+        <div class="material-cell"><input type="text" class="mat-vendor" value="${vendor}"></div>
+        <div class="material-cell"><select class="mat-process"></select></div>
+        <div class="material-cell"><input type="text" class="mat-name" value="${name}"></div>
+        <div class="material-cell">
+          <select class="mat-pricing">
+            <option value="WEIGHT">按重量（元/kg）</option>
+            <option value="VOLUME">按体积（元/m³）</option>
+          </select>
+        </div>
+        <div class="material-cell material-price-cell">
           <div class="material-price-wrap">
             <input type="number" class="mat-price-weight" step="0.1" min="0" value="${pricePerKg}">
             <input type="number" class="mat-price-volume" step="0.1" min="0" value="${pricePerCubicMeter}" style="display:none;" title="元/立方米">

--- a/3d_quote.html
+++ b/3d_quote.html
@@ -201,32 +201,48 @@
 
     .material-row {
       display: grid;
-      grid-template-columns: 1.2fr 1.5fr 2fr 1.5fr 1.2fr 1fr auto;
+      grid-template-columns: 1.2fr 1.5fr 2fr 1.5fr 1.2fr 0.8fr auto;
       column-gap: 8px;
       align-items: center;
-      padding: 6px 0;
-      border-bottom: 1px dashed #eee;
+      margin-bottom: 8px;
     }
     .material-row select,
     .material-row input,
-    .material-row button {
-      height: 32px;
-      line-height: 32px;
+    .material-row button,
+    .material-row .mini-btn {
+      height: 36px;
+      line-height: 36px;
       box-sizing: border-box;
       font-size: 14px;
       padding: 0 8px;
     }
-    .material-row .unit-label {
-      line-height: 32px;
-      font-size: 14px;
+    .material-row .mini-btn {
+      border-radius: 6px;
+      padding: 0 12px;
+    }
+    .material-row .unit-label,
+    .material-row .unit-text,
+    .material-row .sub-label,
+    .material-row .material-price-hint {
+      font-size: 12px;
+      line-height: 18px;
       color: #555;
     }
+    .material-row .unit-label,
+    .material-row .unit-text {
+      display: flex;
+      align-items: center;
+      height: 36px;
+    }
     .material-header {
-      font-size: 13px;
-      font-weight: 600;
+      display: grid;
+      grid-template-columns: 1.2fr 1.5fr 2fr 1.5fr 1.2fr 0.8fr auto;
+      column-gap: 8px;
+      align-items: center;
+      margin-bottom: 4px;
+      font-size: 14px;
+      font-weight: 500;
       color: #555;
-      padding: 8px 0 6px;
-      border-bottom: 1px solid #e5e7eb;
     }
     .material-price-wrap {
       display: flex;
@@ -752,7 +768,7 @@
           <div>材料名称</div>
           <div>计价模式</div>
           <div>单价</div>
-          <div class="unit-label">单位</div>
+          <div class="unit-text">单位</div>
           <div>操作</div>
         </div>
         <div id="materialsTableBody"></div>
@@ -1260,6 +1276,22 @@
       return rules;
     }
 
+    function computeMachineDepreciationHourly(machine) {
+      if (!machine) return 0;
+      const price = parseFloat(machine.price);
+      const lifeYears = parseFloat(machine.expectedLifeYears);
+      const monthlyHours = parseFloat(machine.expectedMonthlyHours);
+      if (
+        isNaN(price) || price <= 0 ||
+        isNaN(lifeYears) || lifeYears <= 0 ||
+        isNaN(monthlyHours) || monthlyHours <= 0
+      ) {
+        return 0;
+      }
+      const totalHours = lifeYears * 12 * monthlyHours;
+      return totalHours > 0 ? price / totalHours : 0;
+    }
+
 
     // ===== 材料 / 设备：表格构造 =====
     function appendMaterialRow(
@@ -1286,9 +1318,9 @@
             <input type="number" class="mat-price-weight" step="0.1" min="0" value="${pricePerKg}">
             <input type="number" class="mat-price-volume" step="0.1" min="0" value="${pricePerCubicMeter}" style="display:none;" title="元/立方米">
           </div>
-          <div class="hint mat-price-hint material-price-hint">按重量：元/kg</div>
+          <div class="hint mat-price-hint material-price-hint sub-label">按重量：元/kg</div>
         </div>
-        <div class="unit-label mat-unit">元/kg</div>
+        <div class="unit-text mat-unit">元/kg</div>
         <button type="button" class="mini-btn mat-delete">删</button>
       `;
       tbody.appendChild(row);
@@ -3002,7 +3034,12 @@
       const operatorHourly = (processCosts.laborHourlyCost || 0) / (processCosts.machinesPerOperator || 1);
       const overheadHourly = processCosts.overheadHourlyPerMachine || 0;
       const electricityHourly = (machine.powerW ? (machine.powerW / 1000) * (runtimeConfig.electricityPrice || 0) : 0);
-      const machineCostPerPart = totalHours * (machine.hourlyRate + operatorHourly + overheadHourly + electricityHourly);
+      const baseMachineHourly = machine.hourlyRate || 0;
+      const depreciationHourly = computeMachineDepreciationHourly(machine);
+      const machineHourly = baseMachineHourly > 0 ? baseMachineHourly : depreciationHourly;
+      const operationalHourly = operatorHourly + overheadHourly + electricityHourly;
+      const effectiveMachineHourly = machineHourly + (baseMachineHourly > 0 ? 0 : operationalHourly);
+      const machineCostPerPart = totalHours * effectiveMachineHourly;
       const totalPostMinutes = (post.baseMinutes || 0) + (post.minutesPerGram || 0) * weight;
       const postLaborCost = (processCosts.laborHourlyCost || 0) * totalPostMinutes / 60;
       const postMaterialCost = (post.extraMaterialCostPerGram || 0) * weight;
@@ -3021,6 +3058,7 @@
       const materialUsageLabel = material.pricingMode === "VOLUME"
         ? `${volume.toFixed(2)} cm³`
         : `${weight.toFixed(2)} g`;
+      const machineHourlyLabel = formatMoney(effectiveMachineHourly);
 
       const resultEl = document.getElementById("result");
       const resultTotalEl = document.getElementById("result-total");
@@ -3032,7 +3070,7 @@
         `▶ 加工类型：${processLabel}`,
         `▶ 材料：${material.vendor} / ${material.name}  ${materialPriceLabel}`,
         `   - 单件耗材：${materialUsageLabel} → 材料成本：${formatMoney(materialCostPerPart)}`,
-        `▶ 设备：${machine.vendor} / ${machine.name}  ${machine.hourlyRate} 元/小时`,
+        `▶ 设备：${machine.vendor} / ${machine.name}  ${machineHourlyLabel} 元/小时`,
         `   - 单件打印时间：${days} 天 ${hours} 小时 ${minutes} 分钟 ≈ ${totalHours.toFixed(2)} 小时`,
         `   - 设备成本：${formatMoney(machineCostPerPart)}`,
         `▶ 后处理：${post.name} → 单件后处理成本：${formatMoney(postCostPerPart)}（时间 ${totalPostMinutes.toFixed(2)} 分钟，人工 ${formatMoney(postLaborCost)}，材料 ${formatMoney(postMaterialCost)}，系数 x${postMultiplier.toFixed(2)}）`,
@@ -3072,6 +3110,8 @@
         postMaterialCost,
         totalPostMinutes,
         setupCostPerPart,
+        machineHourlyRateUsed: effectiveMachineHourly,
+        machineOperationalHourly: baseMachineHourly > 0 ? 0 : operationalHourly,
         costSumPerPart,
         withProfitPerPart,
         finalPricePerPart,
@@ -3108,7 +3148,7 @@
         `材料成本（单件）：${formatMoney(lastQuote.materialCostPerPart)}`,
         "",
         `设备：${lastQuote.machine.vendor} / ${lastQuote.machine.name}`,
-        `设备小时成本：${lastQuote.machine.hourlyRate} 元/小时`,
+        `设备小时成本：${formatMoney(lastQuote.machineHourlyRateUsed || lastQuote.machine.hourlyRate)} 元/小时`,
         `单件打印时间：${lastQuote.days} 天 ${lastQuote.hours} 小时 ${lastQuote.minutes} 分钟 ≈ ${lastQuote.totalHours.toFixed(2)} 小时`,
         `设备成本（单件）：${formatMoney(lastQuote.machineCostPerPart)}`,
         "",

--- a/3d_quote.html
+++ b/3d_quote.html
@@ -198,6 +198,50 @@
     .mini-btn:hover {
       background: #d1d5db;
     }
+
+    .material-row {
+      display: grid;
+      grid-template-columns: 1.2fr 1.5fr 2fr 1.5fr 1.2fr 1fr auto;
+      column-gap: 8px;
+      align-items: center;
+      padding: 6px 0;
+      border-bottom: 1px dashed #eee;
+    }
+    .material-row select,
+    .material-row input,
+    .material-row button {
+      height: 32px;
+      line-height: 32px;
+      box-sizing: border-box;
+      font-size: 14px;
+      padding: 0 8px;
+    }
+    .material-row .unit-label {
+      line-height: 32px;
+      font-size: 14px;
+      color: #555;
+    }
+    .material-header {
+      font-size: 13px;
+      font-weight: 600;
+      color: #555;
+      padding: 8px 0 6px;
+      border-bottom: 1px solid #e5e7eb;
+    }
+    .material-price-wrap {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+    }
+    .material-price-wrap .mat-price-volume,
+    .material-price-wrap .mat-price-weight {
+      width: 100%;
+      min-width: 0;
+    }
+    .material-price-hint {
+      margin-top: 2px;
+      color: #888;
+    }
     .result {
       margin-top: 22px;
       padding-top: 18px;
@@ -617,7 +661,11 @@
     <div class="settings section admin-sub-section active" id="paramsSection">
       <h3>
         全局参数
-        <div>
+        <div style="display:flex;flex-wrap:wrap;gap:6px;align-items:center;">
+          <button type="button" class="mini-btn" id="exportSettingsBtn">导出当前配置</button>
+          <button type="button" class="mini-btn" id="backupSettingsBtn">备份当前配置</button>
+          <button type="button" class="mini-btn" id="restoreBackupBtn">恢复默认配置</button>
+          <button type="button" class="mini-btn" id="restoreFactoryBtn">恢复出厂设置</button>
           <button type="button" class="mini-btn" id="saveSettingsBtn">保存设置到服务器</button>
         </div>
       </h3>
@@ -698,19 +746,16 @@
       </div>
       <small>按计价模式填写单价：重量（元/kg）或体积（元/m³），内容会同步到上方下拉框。</small>
       <div class="table-wrapper">
-        <table>
-          <thead>
-            <tr>
-              <th style="width:16%; min-width:120px;">厂商</th>
-              <th style="width:14%; min-width:120px;">工艺</th>
-              <th style="width:26%; min-width:180px;">材料名称</th>
-              <th style="width:14%; min-width:120px;">计价模式</th>
-              <th style="width:18%; min-width:160px;">单价</th>
-              <th style="width:12%; min-width:90px;">操作</th>
-            </tr>
-          </thead>
-          <tbody id="materialsTableBody"></tbody>
-        </table>
+        <div class="material-row material-header">
+          <div>厂商</div>
+          <div>工艺</div>
+          <div>材料名称</div>
+          <div>计价模式</div>
+          <div>单价</div>
+          <div class="unit-label">单位</div>
+          <div>操作</div>
+        </div>
+        <div id="materialsTableBody"></div>
       </div>
       <div class="pager">
         <label>每页显示</label>
@@ -1099,7 +1144,7 @@
 
     // ===== 材料 / 设备：表格数据读取 =====
     function getMaterialsFromTable() {
-      const rows = document.querySelectorAll("#materialsTableBody tr");
+      const rows = document.querySelectorAll("#materialsTableBody .material-row");
       const arr = [];
       rows.forEach(row => {
         const vendorInput = row.querySelector(".mat-vendor");
@@ -1226,59 +1271,60 @@
       pricePerCubicMeter = ""
     ) {
       const tbody = document.getElementById("materialsTableBody");
-      const tr = document.createElement("tr");
-      tr.innerHTML = `
-        <td><input type="text" class="mat-vendor" value="${vendor}"></td>
-        <td>
-          <select class="mat-process"></select>
-        </td>
-        <td><input type="text" class="mat-name" value="${name}"></td>
-        <td>
-          <select class="mat-pricing">
-            <option value="WEIGHT">按重量（元/kg）</option>
-            <option value="VOLUME">按体积（元/m³）</option>
-          </select>
-        </td>
-        <td class="mat-price-cell">
-          <div class="mat-price-inputs">
+      const row = document.createElement("div");
+      row.className = "material-row";
+      row.innerHTML = `
+        <input type="text" class="mat-vendor" value="${vendor}">
+        <select class="mat-process"></select>
+        <input type="text" class="mat-name" value="${name}">
+        <select class="mat-pricing">
+          <option value="WEIGHT">按重量（元/kg）</option>
+          <option value="VOLUME">按体积（元/m³）</option>
+        </select>
+        <div>
+          <div class="material-price-wrap">
             <input type="number" class="mat-price-weight" step="0.1" min="0" value="${pricePerKg}">
             <input type="number" class="mat-price-volume" step="0.1" min="0" value="${pricePerCubicMeter}" style="display:none;" title="元/立方米">
           </div>
-          <div class="hint mat-price-hint" style="margin-top:6px;">按重量：元/kg</div>
-        </td>
-        <td><button type="button" class="mini-btn mat-delete">删</button></td>
+          <div class="hint mat-price-hint material-price-hint">按重量：元/kg</div>
+        </div>
+        <div class="unit-label mat-unit">元/kg</div>
+        <button type="button" class="mini-btn mat-delete">删</button>
       `;
-      tbody.appendChild(tr);
+      tbody.appendChild(row);
 
-      renderProcessOptions(tr.querySelector(".mat-process"), processType || UNIVERSAL_PROCESS_VALUE, { includeUniversal: true });
+      renderProcessOptions(row.querySelector(".mat-process"), processType || UNIVERSAL_PROCESS_VALUE, { includeUniversal: true });
 
-      const pricingSelect = tr.querySelector(".mat-pricing");
+      const pricingSelect = row.querySelector(".mat-pricing");
       pricingSelect.value = pricingMode === "VOLUME" ? "VOLUME" : "WEIGHT";
       function syncMaterialPriceInputs() {
         const mode = pricingSelect.value;
-        const weightInput = tr.querySelector(".mat-price-weight");
-        const volumeInput = tr.querySelector(".mat-price-volume");
-        const hint = tr.querySelector(".mat-price-hint");
+        const weightInput = row.querySelector(".mat-price-weight");
+        const volumeInput = row.querySelector(".mat-price-volume");
+        const hint = row.querySelector(".mat-price-hint");
+        const unitLabel = row.querySelector(".mat-unit");
         if (mode === "VOLUME") {
           weightInput.style.display = "none";
           volumeInput.style.display = "inline-block";
           hint.textContent = "按体积：元/m³";
+          unitLabel.textContent = "元/m³";
         } else {
           weightInput.style.display = "inline-block";
           volumeInput.style.display = "none";
           hint.textContent = "按重量：元/kg";
+          unitLabel.textContent = "元/kg";
         }
       }
       syncMaterialPriceInputs();
       pricingSelect.addEventListener("change", () => syncMaterialPriceInputs());
 
-      tr.querySelector(".mat-delete").addEventListener("click", () => {
-        tr.remove();
+      row.querySelector(".mat-delete").addEventListener("click", () => {
+        row.remove();
         rebuildMaterialsVendorFilter();
         rebuildMaterialOptions();
         applyMaterialsPagination();
       });
-      tr.querySelectorAll("input, select").forEach(input => {
+      row.querySelectorAll("input, select").forEach(input => {
         input.addEventListener("input", () => {
           rebuildMaterialsVendorFilter();
           rebuildMaterialOptions();
@@ -1426,7 +1472,7 @@
       currentMaterialsProcessFilter = processFilter;
 
       // 读取表格中的所有厂商（即便当前行还没填写材料名称，也要保留厂商）
-      const rows = document.querySelectorAll("#materialsTableBody tr");
+      const rows = document.querySelectorAll("#materialsTableBody .material-row");
       let vendors = [...new Set(Array.from(rows).map(row => {
         const vInput = row.querySelector(".mat-vendor");
         const pSelect = row.querySelector(".mat-process");
@@ -1488,7 +1534,7 @@
     }
 
     function applyMaterialsPagination() {
-      const rows = Array.from(document.querySelectorAll("#materialsTableBody tr"));
+      const rows = Array.from(document.querySelectorAll("#materialsTableBody .material-row"));
       const processFilter = document.getElementById("materialsProcessFilter")?.value || PROCESS_FILTER_ALL;
       const totalMatched = rows.filter(row => {
         const vInput = row.querySelector(".mat-vendor");
@@ -1915,8 +1961,33 @@
       if (customMarginInput && customMarginInput.value === "") {
         customMarginInput.value = (runtimeConfig.defaultProfitMargin * 100).toFixed(0);
       }
+    }
 
-          }
+    function applySettingsToRuntime(data) {
+      if (!data) return;
+      runtimeConfig.defaultProfitMargin = data.defaultProfitMargin;
+      runtimeConfig.defaultMinPricePerPart = data.defaultMinPricePerPart;
+      runtimeConfig.setupFee = data.setupFee;
+      runtimeConfig.electricityPrice = data.electricityPrice ?? CLIENT_DEFAULTS.electricityPrice;
+      runtimeConfig.materials = (data.materials || []).map(m => ({
+        ...m,
+        processType: m.processType ?? null,
+      }));
+      runtimeConfig.machines = (data.machines || []).map(m => ({
+        ...m,
+        processType: m.processType ?? null,
+      }));
+      runtimeConfig.processCosts = data.processCosts && Object.keys(data.processCosts).length
+        ? data.processCosts
+        : CLIENT_DEFAULTS.processCosts;
+      runtimeConfig.postProcessRules = Array.isArray(data.postProcessRules) && data.postProcessRules.length
+        ? data.postProcessRules.map(r => ({
+            ...r,
+            processType: r.processType ?? null,
+            costMultiplier: r.costMultiplier ?? 1,
+          }))
+        : CLIENT_DEFAULTS.postProcessRules;
+    }
 
     async function loadSettingsFromServer() {
       try {
@@ -1924,28 +1995,7 @@
         const resp = await fetch(`${API_BASE}/settings`, { headers: authHeaders() });
         if (!resp.ok) throw new Error("HTTP " + resp.status);
         const data = await resp.json();
-        runtimeConfig.defaultProfitMargin = data.defaultProfitMargin;
-        runtimeConfig.defaultMinPricePerPart = data.defaultMinPricePerPart;
-        runtimeConfig.setupFee = data.setupFee;
-        runtimeConfig.materials = (data.materials || []).map(m => ({
-          ...m,
-          processType: m.processType ?? null
-        }));
-        runtimeConfig.machines = (data.machines || []).map(m => ({
-          ...m,
-          processType: m.processType ?? null
-        }));
-        runtimeConfig.electricityPrice = data.electricityPrice ?? CLIENT_DEFAULTS.electricityPrice;
-        runtimeConfig.processCosts = data.processCosts && Object.keys(data.processCosts).length
-          ? data.processCosts
-          : CLIENT_DEFAULTS.processCosts;
-        runtimeConfig.postProcessRules = Array.isArray(data.postProcessRules) && data.postProcessRules.length
-          ? data.postProcessRules.map(r => ({
-              ...r,
-              processType: r.processType ?? null,
-              costMultiplier: r.costMultiplier ?? 1,
-            }))
-          : CLIENT_DEFAULTS.postProcessRules;
+        applySettingsToRuntime(data);
 
       } catch (e) {
         console.warn("加载服务器设置失败，使用前端默认值:", e);
@@ -2652,17 +2702,83 @@
           throw new Error(errData.detail || "保存失败");
         }
         const saved = await resp.json();
-        runtimeConfig.defaultProfitMargin = saved.defaultProfitMargin;
-        runtimeConfig.defaultMinPricePerPart = saved.defaultMinPricePerPart;
-        runtimeConfig.setupFee = saved.setupFee;
-        runtimeConfig.materials = saved.materials;
-        runtimeConfig.machines = saved.machines;
-        runtimeConfig.postProcessRules = saved.postProcessRules;
-        runtimeConfig.processCosts = saved.processCosts || runtimeConfig.processCosts;
+        applySettingsToRuntime(saved);
         rebuildPostProcessOptions();
+        initSettingsFromRuntime();
         alert("设置已保存到服务器。");
       } catch (e) {
         alert("保存设置失败：" + e.message);
+      }
+    }
+
+    async function exportCurrentSettings() {
+      if (!isAdmin || !sessionToken) {
+        alert("请先以管理员身份登录。");
+        return;
+      }
+      try {
+        const resp = await fetch(`${API_BASE}/settings/export`, { headers: authHeaders() });
+        if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+        const data = await resp.json();
+        const blob = new Blob([JSON.stringify(data, null, 2)], { type: "application/json" });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = `quote_settings_${Date.now()}.json`;
+        a.click();
+        URL.revokeObjectURL(url);
+      } catch (e) {
+        alert(`导出失败：${e.message}`);
+      }
+    }
+
+    async function backupCurrentSettings() {
+      if (!isAdmin || !sessionToken) {
+        alert("请先以管理员身份登录。");
+        return;
+      }
+      try {
+        const resp = await fetch(`${API_BASE}/settings/backup`, { method: "POST", headers: authHeaders() });
+        if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+        alert("已备份当前配置。");
+      } catch (e) {
+        alert(`备份失败：${e.message}`);
+      }
+    }
+
+    async function restoreBackupSettings() {
+      if (!isAdmin || !sessionToken) {
+        alert("请先以管理员身份登录。");
+        return;
+      }
+      if (!window.confirm("确定要恢复到最近的备份配置吗？当前未保存的修改将会丢失。")) return;
+      try {
+        const resp = await fetch(`${API_BASE}/settings/restore`, { method: "POST", headers: authHeaders() });
+        if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+        const data = await resp.json();
+        applySettingsToRuntime(data);
+        initSettingsFromRuntime();
+        alert("已恢复到备份配置。");
+      } catch (e) {
+        alert(`恢复失败：${e.message}`);
+      }
+    }
+
+    async function restoreFactorySettings() {
+      if (!isAdmin || !sessionToken) {
+        alert("请先以管理员身份登录。");
+        return;
+      }
+      if (!window.confirm("确定要恢复到出厂默认配置吗？当前配置将被覆盖。")) return;
+      try {
+        const resp = await fetch(`${API_BASE}/settings/restore-factory`, { method: "POST", headers: authHeaders() });
+        if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+        const data = await resp.json();
+        applySettingsToRuntime(data);
+        initSettingsFromRuntime();
+        alert("已恢复出厂设置并应用到界面。");
+      } catch (e) {
+        alert(`恢复失败：${e.message}`);
       }
     }
 
@@ -2752,6 +2868,10 @@
     }
 
     document.getElementById("saveSettingsBtn").addEventListener("click", saveSettingsToServer);
+    document.getElementById("exportSettingsBtn").addEventListener("click", exportCurrentSettings);
+    document.getElementById("backupSettingsBtn").addEventListener("click", backupCurrentSettings);
+    document.getElementById("restoreBackupBtn").addEventListener("click", restoreBackupSettings);
+    document.getElementById("restoreFactoryBtn").addEventListener("click", restoreFactorySettings);
     document.getElementById("changePasswordBtn").addEventListener("click", changeAdminPassword);
     document.getElementById("saveSettingsBtnMaterials").addEventListener("click", saveSettingsToServer);
     document.getElementById("saveSettingsBtnMachines").addEventListener("click", saveSettingsToServer);

--- a/3d_quote.html
+++ b/3d_quote.html
@@ -244,19 +244,45 @@
       font-weight: 500;
       color: #555;
     }
-    .material-price-wrap {
+    .material-price-cell {
       display: flex;
       align-items: center;
-      gap: 6px;
+      gap: 8px;
+    }
+    .material-price-wrap {
+      display: flex;
+      flex-direction: column;
+      gap: 2px;
     }
     .material-price-wrap .mat-price-volume,
     .material-price-wrap .mat-price-weight {
       width: 100%;
       min-width: 0;
+      height: 36px;
+      line-height: 36px;
+      font-size: 14px;
+      box-sizing: border-box;
+      padding: 0 8px;
+    }
+    .material-price-wrap .mat-price-volume[style*="display:none"] {
+      height: 0;
+      padding: 0;
+      margin: 0;
+      border: 0;
     }
     .material-price-hint {
-      margin-top: 2px;
+      margin-top: 0;
       color: #888;
+    }
+    .material-price-cell .unit-text.mat-unit {
+      font-size: 14px;
+      line-height: 36px;
+    }
+    .material-price-cell .mini-btn.mat-delete {
+      height: 36px;
+      line-height: 36px;
+      font-size: 14px;
+      padding: 0 12px;
     }
     .result {
       margin-top: 22px;
@@ -1218,6 +1244,12 @@
         // 没填名字就跳过这一行
         if (!name) return;
 
+        const hasDepreciationInputs = !(
+          isNaN(price) || price <= 0 ||
+          isNaN(life) || life <= 0 ||
+          isNaN(monthH) || monthH <= 0
+        );
+
         arr.push({
           vendor,
           name,
@@ -1228,7 +1260,8 @@
           expectedLifeYears: isNaN(life) || life <= 0 ? null : life,
           expectedMonthlyHours: isNaN(monthH) || monthH <= 0 ? null : monthH,
           powerW: isNaN(power) || power <= 0 ? null : power,
-          processType: normalizedProcess
+          processType: normalizedProcess,
+          hourlyRateIncludesOperational: hasDepreciationInputs ? false : null
         });
       });
       return arr;
@@ -1313,15 +1346,15 @@
           <option value="WEIGHT">按重量（元/kg）</option>
           <option value="VOLUME">按体积（元/m³）</option>
         </select>
-        <div>
+        <div class="material-price-cell">
           <div class="material-price-wrap">
             <input type="number" class="mat-price-weight" step="0.1" min="0" value="${pricePerKg}">
             <input type="number" class="mat-price-volume" step="0.1" min="0" value="${pricePerCubicMeter}" style="display:none;" title="元/立方米">
+            <div class="hint mat-price-hint material-price-hint sub-label">按重量：元/kg</div>
           </div>
-          <div class="hint mat-price-hint material-price-hint sub-label">按重量：元/kg</div>
+          <div class="unit-text mat-unit">元/kg</div>
+          <button type="button" class="mini-btn mat-delete">删</button>
         </div>
-        <div class="unit-text mat-unit">元/kg</div>
-        <button type="button" class="mini-btn mat-delete">删</button>
       `;
       tbody.appendChild(row);
 
@@ -3038,7 +3071,16 @@
       const depreciationHourly = computeMachineDepreciationHourly(machine);
       const machineHourly = baseMachineHourly > 0 ? baseMachineHourly : depreciationHourly;
       const operationalHourly = operatorHourly + overheadHourly + electricityHourly;
-      const effectiveMachineHourly = machineHourly + (baseMachineHourly > 0 ? 0 : operationalHourly);
+      const hasDepreciationInputs =
+        !!(parseFloat(machine.price) > 0 && parseFloat(machine.expectedLifeYears) > 0 && parseFloat(machine.expectedMonthlyHours) > 0);
+      const hourlyRateIncludesOperational = machine.hourlyRateIncludesOperational;
+      const effectiveMachineHourly = machineHourly + (
+        hourlyRateIncludesOperational === true
+          ? 0
+          : hourlyRateIncludesOperational === false
+            ? operationalHourly
+            : (hasDepreciationInputs ? operationalHourly : 0)
+      );
       const machineCostPerPart = totalHours * effectiveMachineHourly;
       const totalPostMinutes = (post.baseMinutes || 0) + (post.minutesPerGram || 0) * weight;
       const postLaborCost = (processCosts.laborHourlyCost || 0) * totalPostMinutes / 60;

--- a/quote_api.py
+++ b/quote_api.py
@@ -817,7 +817,11 @@ def account_change_username(
     if not account:
         raise HTTPException(status_code=400, detail="账号不存在")
 
-    if get_account(body.newUsername):
+    new_username = body.newUsername.strip()
+    if not new_username:
+        raise HTTPException(status_code=400, detail="新用户名不能为空")
+
+    if get_account(new_username):
         raise HTTPException(status_code=400, detail="目标用户名已存在")
 
     if not verify_password(body.password, account.salt, account.password_hash):
@@ -828,7 +832,7 @@ def account_change_username(
         if acc.username == account.username:
             updated_accounts.append(
                 Account(
-                    username=body.newUsername,
+                    username=new_username,
                     salt=acc.salt,
                     password_hash=acc.password_hash,
                     role=acc.role,

--- a/quote_api.py
+++ b/quote_api.py
@@ -21,6 +21,7 @@ app.add_middleware(
 )
 
 SETTINGS_FILE = "/data/settings.json"
+SETTINGS_BACKUP_FILE = "/data/settings.backup.json"
 ACCOUNT_FILE = "/data/admin_account.json"
 USER_ACCOUNT_FILE = "/data/user_account.json"
 ACCOUNTS_FILE = "/data/accounts.json"
@@ -379,6 +380,23 @@ def save_settings(settings: Settings):
         json.dump(settings.dict(), f, ensure_ascii=False, indent=2)
 
 
+def save_settings_backup(settings: Settings):
+    os.makedirs(os.path.dirname(SETTINGS_BACKUP_FILE), exist_ok=True)
+    with open(SETTINGS_BACKUP_FILE, "w", encoding="utf-8") as f:
+        json.dump(settings.dict(), f, ensure_ascii=False, indent=2)
+
+
+def load_settings_backup() -> Settings:
+    if not os.path.exists(SETTINGS_BACKUP_FILE):
+        raise FileNotFoundError("备份不存在")
+    try:
+        with open(SETTINGS_BACKUP_FILE, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        return Settings(**data)
+    except Exception as exc:
+        raise RuntimeError(f"无法读取备份：{exc}") from exc
+
+
 # ====== 工具函数：密码 & 账户 ======
 
 def hash_password(password: str, salt: str) -> str:
@@ -582,6 +600,60 @@ def update_settings(
 
     save_settings(settings)
     return settings
+
+
+@app.get("/api/settings/export", response_model=Settings)
+def export_settings(
+    x_user_session: Optional[str] = Header(None),
+    x_admin_session: Optional[str] = Header(None),
+    x_session: Optional[str] = Header(None),
+):
+    """导出当前配置，仅管理员可用。"""
+    require_admin(x_admin_session, x_user_session, x_session)
+    return load_settings()
+
+
+@app.post("/api/settings/backup", response_model=Settings)
+def backup_settings(
+    x_user_session: Optional[str] = Header(None),
+    x_admin_session: Optional[str] = Header(None),
+    x_session: Optional[str] = Header(None),
+):
+    """将当前配置写入备份文件。"""
+    require_admin(x_admin_session, x_user_session, x_session)
+    current = load_settings()
+    save_settings_backup(current)
+    return current
+
+
+@app.post("/api/settings/restore", response_model=Settings)
+def restore_from_backup(
+    x_user_session: Optional[str] = Header(None),
+    x_admin_session: Optional[str] = Header(None),
+    x_session: Optional[str] = Header(None),
+):
+    """从备份恢复配置。"""
+    require_admin(x_admin_session, x_user_session, x_session)
+    try:
+        restored = load_settings_backup()
+    except FileNotFoundError:
+        raise HTTPException(status_code=404, detail="未找到备份，请先备份配置")
+    except RuntimeError as exc:
+        raise HTTPException(status_code=500, detail=str(exc))
+    save_settings(restored)
+    return restored
+
+
+@app.post("/api/settings/restore-factory", response_model=Settings)
+def restore_factory_settings(
+    x_user_session: Optional[str] = Header(None),
+    x_admin_session: Optional[str] = Header(None),
+    x_session: Optional[str] = Header(None),
+):
+    """恢复出厂默认配置。"""
+    require_admin(x_admin_session, x_user_session, x_session)
+    save_settings(DEFAULT_SETTINGS)
+    return DEFAULT_SETTINGS
 
 
 # ====== 统一登录 / 登出 / 状态 ======

--- a/quote_api.py
+++ b/quote_api.py
@@ -78,9 +78,12 @@ class Settings(BaseModel):
 
     # 新增：全局成本参数
     electricityPrice: float = 1.0           # 电价 元/kWh
-    laborHourlyCost: float = 25.0           # 操作人工成本 元/人·小时
-    machinesPerOperator: float = 3.0        # 每名操作员平均负责几台机
-    overheadHourlyPerMachine: float = 2.0   # 其他杂项成本 元/台·小时
+    laborHourlyCost: float = 25.0           # 操作人工成本 元/人·小时（兼容旧版全局）
+    machinesPerOperator: float = 3.0        # 每名操作员平均负责几台机（兼容旧版全局）
+    overheadHourlyPerMachine: float = 2.0   # 其他杂项成本 元/台·小时（兼容旧版全局）
+
+    # 按工艺的成本参数
+    processCosts: Dict[str, Dict[str, float]] | None = None
 
     # 新增：后处理规则列表
     postProcessRules: List[PostProcessRule] = []
@@ -111,6 +114,11 @@ class LoginResponse(BaseModel):
 class ChangePasswordRequest(BaseModel):
     oldPassword: str
     newPassword: str
+
+
+class ChangeUsernameRequest(BaseModel):
+    password: str
+    newUsername: str
 
 
 class QuoteRecordCreate(BaseModel):
@@ -186,6 +194,29 @@ DEFAULT_SETTINGS = Settings(
     laborHourlyCost=25.0,
     machinesPerOperator=3.0,
     overheadHourlyPerMachine=2.0,
+
+    processCosts={
+        "FDM_3D_PRINT": {
+            "laborHourlyCost": 25.0,
+            "machinesPerOperator": 3.0,
+            "overheadHourlyPerMachine": 2.0,
+        },
+        "RESIN_3D_PRINT": {
+            "laborHourlyCost": 30.0,
+            "machinesPerOperator": 2.0,
+            "overheadHourlyPerMachine": 3.0,
+        },
+        "CNC_MILLING": {
+            "laborHourlyCost": 35.0,
+            "machinesPerOperator": 1.0,
+            "overheadHourlyPerMachine": 5.0,
+        },
+        "CO2_LASER_ENGRAVE_CUT": {
+            "laborHourlyCost": 28.0,
+            "machinesPerOperator": 2.0,
+            "overheadHourlyPerMachine": 3.0,
+        },
+    },
 
     postProcessRules=[
         PostProcessRule(
@@ -265,6 +296,41 @@ def load_settings() -> Settings:
         materials = [_migrate_old_material(m) for m in mats]
         machines = [_migrate_old_machine(m) for m in macs]
 
+        loaded_process_costs = data.get("processCosts")
+
+        # 兼容旧版：如果没有 processCosts，就用全局值填充所有工艺
+        default_process_costs = DEFAULT_SETTINGS.processCosts or {}
+        merged_process_costs = {}
+        if isinstance(loaded_process_costs, dict):
+            merged_process_costs = {
+                k: {
+                    "laborHourlyCost": v.get(
+                        "laborHourlyCost", data.get("laborHourlyCost", DEFAULT_SETTINGS.laborHourlyCost)
+                    ),
+                    "machinesPerOperator": v.get(
+                        "machinesPerOperator",
+                        data.get("machinesPerOperator", DEFAULT_SETTINGS.machinesPerOperator),
+                    ),
+                    "overheadHourlyPerMachine": v.get(
+                        "overheadHourlyPerMachine",
+                        data.get("overheadHourlyPerMachine", DEFAULT_SETTINGS.overheadHourlyPerMachine),
+                    ),
+                }
+                for k, v in loaded_process_costs.items()
+                if isinstance(v, dict)
+            }
+        else:
+            merged_process_costs = {
+                k: {
+                    "laborHourlyCost": data.get("laborHourlyCost", DEFAULT_SETTINGS.laborHourlyCost),
+                    "machinesPerOperator": data.get("machinesPerOperator", DEFAULT_SETTINGS.machinesPerOperator),
+                    "overheadHourlyPerMachine": data.get(
+                        "overheadHourlyPerMachine", DEFAULT_SETTINGS.overheadHourlyPerMachine
+                    ),
+                }
+                for k in default_process_costs.keys()
+            }
+
         return Settings(
             materials=materials,
             machines=machines,
@@ -298,6 +364,8 @@ def load_settings() -> Settings:
                 if isinstance(post_rules, list)
                 else DEFAULT_SETTINGS.postProcessRules
             ),
+
+            processCosts=merged_process_costs or DEFAULT_SETTINGS.processCosts,
         )
 
     except Exception as e:
@@ -613,6 +681,8 @@ def admin_change_password(
                     password_hash=new_hash,
                     role=acc.role,
                     active=acc.active,
+                    recordEnabled=acc.recordEnabled,
+                    canViewRecords=acc.canViewRecords,
                 )
             )
         else:
@@ -621,6 +691,86 @@ def admin_change_password(
     _persist_accounts(updated_accounts)
     invalidate_sessions_for(account.username)
     return {"message": "密码已更新，请使用新密码重新登录"}
+
+
+@app.post("/api/account/change-password")
+def account_change_password(
+    body: ChangePasswordRequest,
+    x_session: Optional[str] = Header(None),
+    x_admin_session: Optional[str] = Header(None),
+    x_user_session: Optional[str] = Header(None),
+):
+    """普通用户或管理员修改自己的密码。"""
+    session = require_authenticated(x_user_session, x_admin_session, x_session)
+    account = get_account(session["username"])
+    if not account:
+        raise HTTPException(status_code=400, detail="账号不存在")
+
+    if not verify_password(body.oldPassword, account.salt, account.password_hash):
+        raise HTTPException(status_code=403, detail="旧密码不正确")
+
+    new_salt = secrets.token_hex(16)
+    new_hash = hash_password(body.newPassword, new_salt)
+    updated_accounts: List[Account] = []
+    for acc in ACCOUNTS:
+        if acc.username == account.username:
+            updated_accounts.append(
+                Account(
+                    username=acc.username,
+                    salt=new_salt,
+                    password_hash=new_hash,
+                    role=acc.role,
+                    active=acc.active,
+                    recordEnabled=acc.recordEnabled,
+                    canViewRecords=acc.canViewRecords,
+                )
+            )
+        else:
+            updated_accounts.append(acc)
+    _persist_accounts(updated_accounts)
+    invalidate_sessions_for(account.username)
+    return {"message": "密码已更新，请使用新密码重新登录"}
+
+
+@app.post("/api/account/change-username")
+def account_change_username(
+    body: ChangeUsernameRequest,
+    x_session: Optional[str] = Header(None),
+    x_admin_session: Optional[str] = Header(None),
+    x_user_session: Optional[str] = Header(None),
+):
+    """普通用户或管理员修改自己的用户名。"""
+    session = require_authenticated(x_user_session, x_admin_session, x_session)
+    account = get_account(session["username"])
+    if not account:
+        raise HTTPException(status_code=400, detail="账号不存在")
+
+    if get_account(body.newUsername):
+        raise HTTPException(status_code=400, detail="目标用户名已存在")
+
+    if not verify_password(body.password, account.salt, account.password_hash):
+        raise HTTPException(status_code=403, detail="密码验证失败")
+
+    updated_accounts: List[Account] = []
+    for acc in ACCOUNTS:
+        if acc.username == account.username:
+            updated_accounts.append(
+                Account(
+                    username=body.newUsername,
+                    salt=acc.salt,
+                    password_hash=acc.password_hash,
+                    role=acc.role,
+                    active=acc.active,
+                    recordEnabled=acc.recordEnabled,
+                    canViewRecords=acc.canViewRecords,
+                )
+            )
+        else:
+            updated_accounts.append(acc)
+
+    _persist_accounts(updated_accounts)
+    invalidate_sessions_for(account.username)
+    return {"message": "用户名已更新，请使用新用户名重新登录"}
 
 
 class UserPublic(BaseModel):


### PR DESCRIPTION
## Summary
- add per-process cost configuration that is saved with settings and used in pricing calculations
- provide self-service username/password updates plus relocate admin password control and save actions across settings tabs
- normalize material price inputs and default profit margin handling in the quote form

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923271e1dc08329a7e69b1b9ebbfbc5)