### PR TITLE
Move quote pricing to backend

### DIFF
--- a/3d_quote.html
+++ b/3d_quote.html
@@ -2815,6 +2815,7 @@
         const projectSelect = document.getElementById("projectSelect");
         const projectId = projectSelect?.value || "";
         const projectName = cachedProjects.find(p => p.id === projectId)?.name || "";
+        const postProcess = quote.postProcess || quote.post || {};
         const resp = await fetch(`${API_BASE}/quotes`, {
           method: "POST",
           headers: { "Content-Type": "application/json", ...authHeaders() },
@@ -2825,6 +2826,8 @@
             totalPrice: quote.totalPrice,
             finalPricePerPart: quote.finalPricePerPart,
             costSumPerPart: quote.costSumPerPart,
+            withProfitPerPart: quote.withProfitPerPart,
+            minPricePerPart: quote.minPricePerPart,
             profitMargin: quote.profitMargin,
             materialCostPerPart: quote.materialCostPerPart,
             machineCostPerPart: quote.machineCostPerPart,
@@ -2832,10 +2835,13 @@
             setupCostPerPart: quote.setupCostPerPart,
             material: quote.material,
             machine: quote.machine,
-            postProcess: quote.post,
+            postProcess,
             weight: quote.weight,
             volume: quote.volume,
             totalHours: quote.totalHours,
+            days: quote.days,
+            hours: quote.hours,
+            minutes: quote.minutes,
             projectId: projectId || null,
             projectName: projectName || undefined,
             visibility: recordVisibility
@@ -3348,6 +3354,61 @@
       }
     });
 
+    function renderQuoteResult(quote) {
+      const resultEl = document.getElementById("result");
+      const resultTotalEl = document.getElementById("result-total");
+      const resultDetailEl = document.getElementById("result-detail");
+      if (!resultEl || !resultTotalEl || !resultDetailEl) return;
+
+      const material = quote.material || {};
+      const machine = quote.machine || {};
+      const post = quote.postProcess || quote.post || {};
+      const weight = quote.weight ?? 0;
+      const volume = quote.volume ?? 0;
+      const days = quote.days ?? 0;
+      const hours = quote.hours ?? 0;
+      const minutes = quote.minutes ?? 0;
+      const totalHours = quote.totalHours ?? 0;
+      const quantity = quote.quantity ?? 0;
+      const postMultiplier = quote.postMultiplier ?? 1;
+      const setupFee = quote.setupFee ?? runtimeConfig.setupFee ?? 0;
+
+      const materialPriceLabel = material.pricingMode === "VOLUME"
+        ? `${material.pricePerCubicMeter ?? 0} 元/m³`
+        : `${material.pricePerKg ?? 0} 元/kg`;
+      const materialUsageLabel = material.pricingMode === "VOLUME"
+        ? `${volume.toFixed(2)} cm³`
+        : `${weight.toFixed(2)} g`;
+      const machineHourlyLabel = formatMoney(quote.machineHourlyRateUsed ?? machine.hourlyRate ?? 0);
+
+      resultTotalEl.textContent = `${formatMoney(quote.totalPrice)}  （共 ${quantity} 件，单件 ${formatMoney(quote.finalPricePerPart)}）`;
+
+      const lines = [
+        `▶ 加工类型：${quote.processLabel || quote.processType}`,
+        `▶ 材料：${material.vendor} / ${material.name}  ${materialPriceLabel}`,
+        `   - 单件耗材：${materialUsageLabel} → 材料成本：${formatMoney(quote.materialCostPerPart)}`,
+        `▶ 设备：${machine.vendor} / ${machine.name}  ${machineHourlyLabel} 元/小时`,
+        `   - 单件打印时间：${days} 天 ${hours} 小时 ${minutes} 分钟 ≈ ${totalHours.toFixed(2)} 小时`,
+        `   - 设备成本：${formatMoney(quote.machineCostPerPart)}`,
+        `▶ 后处理：${post.name} → 单件后处理成本：${formatMoney(quote.postCostPerPart)}（时间 ${(quote.totalPostMinutes ?? 0).toFixed(2)} 分钟，人工 ${formatMoney(quote.postLaborCost ?? 0)}，材料 ${formatMoney(quote.postMaterialCost ?? 0)}，系数 x${postMultiplier.toFixed(2)}）`,
+        `▶ 上机/调机费（订单）：${formatMoney(setupFee)}  分摊后每件：${formatMoney(quote.setupCostPerPart)}`,
+        "",
+        `▶ 单件成本小计：${formatMoney(quote.costSumPerPart)}`,
+        `▶ 利润率：${((quote.profitMargin ?? 0) * 100).toFixed(0)}%`,
+        `▶ 单件最低价：${formatMoney(quote.minPricePerPart)}`,
+        `▶ 含利润单价：${formatMoney(quote.withProfitPerPart ?? 0)}`,
+        `▶ 最终计价单件：${formatMoney(quote.finalPricePerPart)}`,
+        "",
+        `▶ 数量：${quantity} 件`,
+        `▶ 订单总价：${formatMoney(quote.totalPrice)}`
+      ];
+
+      resultDetailEl.textContent = lines.join("\n");
+      resultEl.style.display = "block";
+
+      lastQuote = { ...quote, post };
+    }
+
     // ===== 报价计算 & 导出 =====
     document.getElementById("quote-form").addEventListener("submit", function (e) {
       e.preventDefault();
@@ -3412,84 +3473,15 @@
       const customMarginInput = document.getElementById("customMargin").value;
       const customMinInput = document.getElementById("customMin").value;
 
-      const profitMargin = customMarginInput !== ""
-        ? (parseFloat(customMarginInput) || 0) / 100
-        : runtimeConfig.defaultProfitMargin;
-
-      const minPricePerPart = customMinInput !== ""
-        ? (parseFloat(customMinInput) || 0)
-        : runtimeConfig.defaultMinPricePerPart;
-
-      const processCosts = getProcessCostConfig(processType);
-      const materialCostPerPart = material.pricingMode === "VOLUME"
-        ? ((volume / 1000000) * (material.pricePerCubicMeter || 0))
-        : ((weight / 1000) * (material.pricePerKg || 0));
-      const operatorHourly = (processCosts.laborHourlyCost || 0) / (processCosts.machinesPerOperator || 1);
-      const overheadHourly = processCosts.overheadHourlyPerMachine || 0;
-      const electricityHourly = (machine.powerW ? (machine.powerW / 1000) * (runtimeConfig.electricityPrice || 0) : 0);
-      const baseMachineHourly = machine.hourlyRate || 0;
-      const depreciationHourly = computeMachineDepreciationHourly(machine);
-      const machineHourly = baseMachineHourly > 0 ? baseMachineHourly : depreciationHourly;
-      const operationalHourly = operatorHourly + overheadHourly + electricityHourly;
-      const hourlyRateIncludesOperational = machine.hourlyRateIncludesOperational;
-      const inferredAllIn = hourlyRateIncludesOperational === true
-        || (hourlyRateIncludesOperational == null && baseMachineHourly > 0 && depreciationHourly === 0);
-      const shouldAddOperational = !inferredAllIn;
-      const effectiveMachineHourly = machineHourly + (shouldAddOperational ? operationalHourly : 0);
-      const machineCostPerPart = totalHours * effectiveMachineHourly;
-      const totalPostMinutes = (post.baseMinutes || 0) + (post.minutesPerGram || 0) * weight;
-      const postLaborCost = (processCosts.laborHourlyCost || 0) * totalPostMinutes / 60;
-      const postMaterialCost = (post.extraMaterialCostPerGram || 0) * weight;
-      const postMultiplier = post.costMultiplier || 1;
-      const postCostPerPart = (postLaborCost + postMaterialCost) * postMultiplier;
-      const setupCostPerPart = quantity > 0 ? runtimeConfig.setupFee / quantity : runtimeConfig.setupFee;
-
-      const costSumPerPart = materialCostPerPart + machineCostPerPart + postCostPerPart + setupCostPerPart;
-      const withProfitPerPart = costSumPerPart * (1 + profitMargin);
-      const finalPricePerPart = Math.max(withProfitPerPart, minPricePerPart);
-      const totalPrice = finalPricePerPart * quantity;
-
-      const materialPriceLabel = material.pricingMode === "VOLUME"
-        ? `${material.pricePerCubicMeter ?? 0} 元/m³`
-        : `${material.pricePerKg ?? 0} 元/kg`;
-      const materialUsageLabel = material.pricingMode === "VOLUME"
-        ? `${volume.toFixed(2)} cm³`
-        : `${weight.toFixed(2)} g`;
-      const machineHourlyLabel = formatMoney(effectiveMachineHourly);
-
-      const resultEl = document.getElementById("result");
-      const resultTotalEl = document.getElementById("result-total");
-      const resultDetailEl = document.getElementById("result-detail");
-
-      resultTotalEl.textContent = `${formatMoney(totalPrice)}  （共 ${quantity} 件，单件 ${formatMoney(finalPricePerPart)}）`;
-
-      const lines = [
-        `▶ 加工类型：${processLabel}`,
-        `▶ 材料：${material.vendor} / ${material.name}  ${materialPriceLabel}`,
-        `   - 单件耗材：${materialUsageLabel} → 材料成本：${formatMoney(materialCostPerPart)}`,
-        `▶ 设备：${machine.vendor} / ${machine.name}  ${machineHourlyLabel} 元/小时`,
-        `   - 单件打印时间：${days} 天 ${hours} 小时 ${minutes} 分钟 ≈ ${totalHours.toFixed(2)} 小时`,
-        `   - 设备成本：${formatMoney(machineCostPerPart)}`,
-        `▶ 后处理：${post.name} → 单件后处理成本：${formatMoney(postCostPerPart)}（时间 ${totalPostMinutes.toFixed(2)} 分钟，人工 ${formatMoney(postLaborCost)}，材料 ${formatMoney(postMaterialCost)}，系数 x${postMultiplier.toFixed(2)}）`,
-        `▶ 上机/调机费（订单）：${formatMoney(runtimeConfig.setupFee)}  分摊后每件：${formatMoney(setupCostPerPart)}`,
-        "",
-        `▶ 单件成本小计：${formatMoney(costSumPerPart)}`,
-        `▶ 利润率：${(profitMargin * 100).toFixed(0)}%`,
-        `▶ 单件最低价：${formatMoney(minPricePerPart)}`,
-        `▶ 含利润单价：${formatMoney(withProfitPerPart)}`,
-        `▶ 最终计价单件：${formatMoney(finalPricePerPart)}`,
-        "",
-        `▶ 数量：${quantity} 件`,
-        `▶ 订单总价：${formatMoney(totalPrice)}`
-      ];
-
-      resultDetailEl.textContent = lines.join("\n");
-      resultEl.style.display = "block";
-
-      lastQuote = {
-        material,
-        machine,
-        post,
+      const payload = {
+        processType,
+        processLabel,
+        materialVendor: material.vendor,
+        materialName: material.name,
+        materialPricingMode: material.pricingMode,
+        machineVendor: machine.vendor,
+        machineName: machine.name,
+        postProcessKey: post.key,
         weight,
         volume,
         days,
@@ -3497,25 +3489,31 @@
         minutes,
         totalHours,
         quantity,
-        profitMargin,
-        minPricePerPart,
-        materialCostPerPart,
-        machineCostPerPart,
-        postCostPerPart,
-        postMultiplier,
-        postLaborCost,
-        postMaterialCost,
-        totalPostMinutes,
-        setupCostPerPart,
-        machineHourlyRateUsed: effectiveMachineHourly,
-        machineOperationalHourly: baseMachineHourly > 0 ? 0 : operationalHourly,
-        costSumPerPart,
-        withProfitPerPart,
-        finalPricePerPart,
-        totalPrice,
-        processType,
-        processLabel
+        profitMargin: customMarginInput !== "" ? ((parseFloat(customMarginInput) || 0) / 100) : null,
+        minPricePerPart: customMinInput !== "" ? (parseFloat(customMinInput) || 0) : null,
       };
+
+      try {
+        const resp = await fetch(`${API_BASE}/calc-quote`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json", ...authHeaders() },
+          body: JSON.stringify(payload)
+        });
+        const data = await resp.json().catch(() => ({}));
+        if (!resp.ok) throw new Error(data.detail || "计算失败");
+
+        const normalized = {
+          ...data,
+          processLabel: data.processLabel || processLabel,
+          material: data.material || material,
+          machine: data.machine || machine,
+          postProcess: data.postProcess || post,
+          post: data.postProcess || post,
+        };
+        renderQuoteResult(normalized);
+      } catch (err) {
+        alert(err.message || "计算失败");
+      }
 
     });
 
@@ -3533,6 +3531,7 @@
       persistQuoteResult(lastQuote);
       const now = new Date();
       const dateStr = now.toLocaleString("zh-CN");
+      const setupFee = lastQuote.setupFee ?? runtimeConfig.setupFee;
       const lines = [
         "加工报价单",
         "========================",
@@ -3552,7 +3551,7 @@
         `后处理等级：${lastQuote.post.name}`,
         `后处理成本（单件）：${formatMoney(lastQuote.postCostPerPart)}（时间 ${lastQuote.totalPostMinutes.toFixed(2)} 分钟，人工 ${formatMoney(lastQuote.postLaborCost)}, 材料 ${formatMoney(lastQuote.postMaterialCost)}, 系数 x${(lastQuote.postMultiplier || 1).toFixed(2)}）`,
         "",
-        `上机/调机费（订单）：${formatMoney(runtimeConfig.setupFee)}`,
+        `上机/调机费（订单）：${formatMoney(setupFee)}`,
         `分摊后上机费（单件）：${formatMoney(lastQuote.setupCostPerPart)}`,
         "",
         `单件成本小计：${formatMoney(lastQuote.costSumPerPart)}`,

--- a/3d_quote.html
+++ b/3d_quote.html
@@ -983,8 +983,23 @@
   </div>
 
   <script>
-    // ===== API 地址：这里改成你的后端地址 =====
-    const API_BASE = "http://10.1.1.21:8000/api";
+    // ===== API 地址：默认同源 /api，可用 window.API_BASE 或 ?api_base= 覆盖 =====
+    const urlParams = new URLSearchParams(window.location.search);
+    const API_BASE = urlParams.get("api_base") || window.API_BASE || "/api";
+
+    // 将管理员 UI 从初始 DOM 中移除，非管理员无法在页面元素里看到
+    const adminMainOriginal = document.getElementById("adminMain");
+    const adminMountPoint = document.createElement("div");
+    adminMountPoint.id = "adminMountPoint";
+    if (adminMainOriginal?.parentNode) {
+      adminMainOriginal.parentNode.insertBefore(adminMountPoint, adminMainOriginal);
+    }
+    const adminMainTemplateHTML = adminMainOriginal?.outerHTML || "";
+    if (adminMainOriginal) adminMainOriginal.remove();
+
+    const adminTabOriginal = document.querySelector('.main-tabs .page-tab[data-main="adminMain"]');
+    const adminTabTemplateHTML = adminTabOriginal?.outerHTML || "";
+    if (adminTabOriginal) adminTabOriginal.remove();
 
     const PROCESS_TYPES = [
       { value: "FDM_3D_PRINT", label: "FDM 3D 打印" },
@@ -1073,6 +1088,8 @@
     let recordsVisibilityFilter = "all";
     let recordVisibilitySelection = "owner_only";
     let cachedProjects = [];
+    let adminEventsBound = false;
+    let adminSubTabsBound = false;
     let projectSearchKeyword = "";
     let editingProjectId = null;
 
@@ -2320,7 +2337,161 @@
       if (target) target.classList.add("active");
     }
 
+    function bindMainTabButton(btn) {
+      if (!btn || btn.dataset.bound === "1") return;
+      btn.dataset.bound = "1";
+      btn.addEventListener("click", () => {
+        if (btn.dataset.main === "adminMain" && !isAdmin) {
+          alert("仅管理员可访问，请先使用管理员账户登录。");
+          return;
+        }
+        if (btn.dataset.main === "recordsMain") {
+          if (!isAuthenticated()) {
+            alert("请先登录后查看报价记录。");
+            return;
+          }
+          if (!isAdmin && !canViewRecords) {
+            alert("当前账号无查看报价记录的权限，请联系管理员开启。");
+            return;
+          }
+        }
+        if (btn.dataset.main === "accountMain" && !isAuthenticated()) {
+          alert("请先登录后再进行账户设置。");
+          return;
+        }
+        setMainTab(btn);
+      });
+    }
+
+    function bindMainTabButtons() {
+      document.querySelectorAll(".main-tabs .page-tab").forEach(bindMainTabButton);
+    }
+
+    function bindAdminSubTabs() {
+      const tabs = document.querySelectorAll("#adminTabs .page-tab");
+      if (!tabs.length) return;
+      tabs.forEach(btn => {
+        if (btn.dataset.bound === "1") return;
+        btn.dataset.bound = "1";
+        btn.addEventListener("click", () => {
+          setAdminSubTab(btn);
+          const targetId = btn.getAttribute("data-section");
+          if (targetId === "recordsSection") {
+            renderQuoteRecords();
+            renderQuoteSummary();
+          }
+          if (targetId === "userManagementSection") {
+            renderUserTable();
+          }
+          if (targetId === "projectSection") {
+            refreshProjects();
+          }
+        });
+      });
+      adminSubTabsBound = true;
+    }
+
+    function bindAdminEventHandlers() {
+      if (adminEventsBound) return;
+      if (!document.getElementById("adminMain")) return;
+
+      document.getElementById("projectCreateBtn")?.addEventListener("click", () => openProjectModal());
+      document.getElementById("projectAdminSearchBtn")?.addEventListener("click", () => {
+        const kw = document.getElementById("projectAdminSearch")?.value || "";
+        refreshProjects(kw);
+      });
+      document.getElementById("projectAdminResetBtn")?.addEventListener("click", () => {
+        const input = document.getElementById("projectAdminSearch");
+        if (input) input.value = "";
+        refreshProjects("");
+      });
+      document.getElementById("projectTableBody")?.addEventListener("click", (e) => {
+        const btn = e.target.closest("button[data-action]");
+        if (!btn) return;
+        const id = btn.getAttribute("data-id");
+        const action = btn.getAttribute("data-action");
+        const project = cachedProjects.find(p => p.id === id);
+        if (action === "edit" && project) {
+          openProjectModal(project);
+        } else if (action === "delete") {
+          deleteProject(id);
+        }
+      });
+      document.getElementById("projectModalSubmit")?.addEventListener("click", submitProjectModal);
+      document.getElementById("projectModalClose")?.addEventListener("click", closeProjectModal);
+      document.getElementById("projectModalCancel")?.addEventListener("click", closeProjectModal);
+
+      document.getElementById("createUserBtn")?.addEventListener("click", createUser);
+      document.getElementById("userTableBody")?.addEventListener("click", (e) => {
+        const btn = e.target.closest("button[data-action]");
+        if (!btn) return;
+        const username = btn.getAttribute("data-username");
+        const action = btn.getAttribute("data-action");
+        if (action === "reset") {
+          resetUserPassword(username);
+        } else if (action === "toggle") {
+          const active = btn.getAttribute("data-active") === "true";
+          toggleUser(username, !active);
+        } else if (action === "edit") {
+          const currentRole = btn.getAttribute("data-role") || "user";
+          const newName = window.prompt("请输入新的用户名（留空则不修改）：", username) || username;
+          const newRole = window.prompt("请输入角色 admin/user：", currentRole) || currentRole;
+          updateUser(username, newName.trim(), newRole.trim());
+        } else if (action === "record") {
+          const user = getCachedUser(username);
+          if (!user) return;
+          updateUser(username, user.username, user.role, { recordEnabled: !user.recordEnabled });
+        } else if (action === "view") {
+          const user = getCachedUser(username);
+          if (!user) return;
+          updateUser(username, user.username, user.role, { canViewRecords: !user.canViewRecords });
+        } else if (action === "delete") {
+          if (window.confirm(`确定要删除用户 ${username} 吗？`)) {
+            deleteUser(username);
+          }
+        }
+      });
+
+      adminEventsBound = true;
+    }
+
+    function mountAdminUI() {
+      if (!isAdmin) return;
+      if (!document.getElementById("adminMain") && adminMainTemplateHTML && adminMountPoint) {
+        adminMountPoint.innerHTML = adminMainTemplateHTML;
+      }
+      const mainTabs = document.querySelector(".main-tabs");
+      if (mainTabs && !document.querySelector('.main-tabs .page-tab[data-main="adminMain"]') && adminTabTemplateHTML) {
+        const temp = document.createElement("div");
+        temp.innerHTML = adminTabTemplateHTML.trim();
+        const tabBtn = temp.firstElementChild;
+        if (tabBtn) {
+          mainTabs.appendChild(tabBtn);
+          bindMainTabButton(tabBtn);
+        }
+      }
+      bindAdminSubTabs();
+      bindAdminEventHandlers();
+    }
+
+    function unmountAdminUI() {
+      const adminTab = document.querySelector('.main-tabs .page-tab[data-main="adminMain"]');
+      if (adminTab) adminTab.remove();
+      const adminMain = document.getElementById("adminMain");
+      if (adminMain) adminMain.remove();
+      if (adminMountPoint) adminMountPoint.innerHTML = "";
+      adminEventsBound = false;
+      adminSubTabsBound = false;
+    }
+
     function updateAuthUI() {
+      if (isAdmin) {
+        mountAdminUI();
+      } else {
+        unmountAdminUI();
+      }
+      bindMainTabButtons();
+
       const loginPanel = document.getElementById("loginPanel");
       const appContent = document.getElementById("appContent");
       const statusEl = document.getElementById("userStatus");
@@ -3580,46 +3751,7 @@
 
     // ===== 页面初始化 =====
     window.addEventListener("DOMContentLoaded", async () => {
-      document.querySelectorAll(".main-tabs .page-tab").forEach(btn => {
-        btn.addEventListener("click", () => {
-          if (btn.dataset.main === "adminMain" && !isAdmin) {
-            alert("仅管理员可访问，请先使用管理员账户登录。");
-            return;
-          }
-          if (btn.dataset.main === "recordsMain") {
-            if (!isAuthenticated()) {
-              alert("请先登录后查看报价记录。");
-              return;
-            }
-            if (!isAdmin && !canViewRecords) {
-              alert("当前账号无查看报价记录的权限，请联系管理员开启。");
-              return;
-            }
-          }
-          if (btn.dataset.main === "accountMain" && !isAuthenticated()) {
-            alert("请先登录后再进行账户设置。");
-            return;
-          }
-          setMainTab(btn);
-        });
-      });
-
-      document.querySelectorAll("#adminTabs .page-tab").forEach(btn => {
-        btn.addEventListener("click", () => {
-          setAdminSubTab(btn);
-          const targetId = btn.getAttribute("data-section");
-          if (targetId === "recordsSection") {
-            renderQuoteRecords();
-            renderQuoteSummary();
-          }
-          if (targetId === "userManagementSection") {
-            renderUserTable();
-          }
-          if (targetId === "projectSection") {
-            refreshProjects();
-          }
-        });
-      });
+      bindMainTabButtons();
       initProcessTypeSelector();
       updateAuthUI();
       await refreshAuthState();

--- a/quote_api.py
+++ b/quote_api.py
@@ -92,6 +92,58 @@ class Settings(BaseModel):
     # 新增：后处理规则列表
     postProcessRules: List[PostProcessRule] = []
 
+
+class CalcQuoteRequest(BaseModel):
+    processType: str
+    processLabel: Optional[str] = None
+    materialVendor: str
+    materialName: str
+    materialPricingMode: Optional[Literal["WEIGHT", "VOLUME"]] = None
+    machineVendor: str
+    machineName: str
+    postProcessKey: str
+    weight: Optional[float] = 0
+    volume: Optional[float] = 0
+    days: float = 0
+    hours: float = 0
+    minutes: float = 0
+    totalHours: Optional[float] = None
+    quantity: int = 1
+    profitMargin: Optional[float] = None
+    minPricePerPart: Optional[float] = None
+
+
+class CalcQuoteResponse(BaseModel):
+    processType: str
+    processLabel: Optional[str] = None
+    quantity: int
+    profitMargin: float
+    minPricePerPart: float
+    withProfitPerPart: float
+    finalPricePerPart: float
+    totalPrice: float
+    costSumPerPart: float
+    materialCostPerPart: float
+    machineCostPerPart: float
+    postCostPerPart: float
+    setupCostPerPart: float
+    setupFee: float
+    material: Material
+    machine: Machine
+    postProcess: PostProcessRule
+    weight: Optional[float] = None
+    volume: Optional[float] = None
+    days: float = 0
+    hours: float = 0
+    minutes: float = 0
+    totalHours: float
+    postLaborCost: float
+    postMaterialCost: float
+    totalPostMinutes: float
+    postMultiplier: float
+    machineHourlyRateUsed: float
+    machineOperationalHourly: float
+
 class Account(BaseModel):
     username: str
     salt: str
@@ -132,6 +184,8 @@ class QuoteRecordCreate(BaseModel):
     totalPrice: float
     finalPricePerPart: float
     costSumPerPart: float
+    withProfitPerPart: Optional[float] = None
+    minPricePerPart: Optional[float] = None
     profitMargin: float
     materialCostPerPart: float
     machineCostPerPart: float
@@ -145,6 +199,9 @@ class QuoteRecordCreate(BaseModel):
     weight: Optional[float] = None
     volume: Optional[float] = None
     totalHours: Optional[float] = None
+    days: Optional[float] = None
+    hours: Optional[float] = None
+    minutes: Optional[float] = None
     visibility: Literal["admin_only", "all_users", "owner_only"] = "admin_only"
     adopted: bool = False
 
@@ -612,6 +669,154 @@ def save_projects(projects: List[Project]):
     os.makedirs(os.path.dirname(PROJECTS_FILE), exist_ok=True)
     with open(PROJECTS_FILE, "w", encoding="utf-8") as f:
         json.dump([p.dict() for p in projects], f, ensure_ascii=False, indent=2)
+
+
+# ====== 报价计算工具 ======
+
+
+def _find_material(settings: Settings, vendor: str, name: str, pricing_mode: Optional[str]) -> Material:
+    for m in settings.materials:
+        if m.vendor == vendor and m.name == name:
+            if pricing_mode and m.pricingMode != pricing_mode:
+                continue
+            return m
+    raise HTTPException(status_code=400, detail="所选材料不存在或已被删除")
+
+
+def _find_machine(settings: Settings, vendor: str, name: str) -> Machine:
+    for m in settings.machines:
+        if m.vendor == vendor and m.name == name:
+            return m
+    raise HTTPException(status_code=400, detail="所选设备不存在或已被删除")
+
+
+def _find_post_rule(settings: Settings, key: str) -> PostProcessRule:
+    for rule in settings.postProcessRules:
+        if rule.key == key:
+            return rule
+    raise HTTPException(status_code=400, detail="所选后处理规则不存在或已被删除")
+
+
+def _compute_machine_depreciation(machine: Machine) -> float:
+    try:
+        price = float(machine.price) if machine.price is not None else None
+        life_years = float(machine.expectedLifeYears) if machine.expectedLifeYears is not None else None
+        monthly_hours = float(machine.expectedMonthlyHours) if machine.expectedMonthlyHours is not None else None
+    except Exception:
+        return 0.0
+    if not price or not life_years or not monthly_hours:
+        return 0.0
+    total_hours = life_years * 12 * monthly_hours
+    return price / total_hours if total_hours > 0 else 0.0
+
+
+def _resolve_process_costs(settings: Settings, process_type: str) -> Dict[str, float]:
+    base = (settings.processCosts or {}).get(process_type) or {}
+    return {
+        "laborHourlyCost": float(base.get("laborHourlyCost", settings.laborHourlyCost or 0)),
+        "machinesPerOperator": float(base.get("machinesPerOperator", settings.machinesPerOperator or 1)) or 1.0,
+        "overheadHourlyPerMachine": float(base.get("overheadHourlyPerMachine", settings.overheadHourlyPerMachine or 0)),
+    }
+
+
+def calculate_quote(data: CalcQuoteRequest, settings: Settings) -> CalcQuoteResponse:
+    if data.quantity <= 0:
+        raise HTTPException(status_code=400, detail="数量必须大于 0")
+
+    material = _find_material(settings, data.materialVendor, data.materialName, data.materialPricingMode)
+    machine = _find_machine(settings, data.machineVendor, data.machineName)
+    post = _find_post_rule(settings, data.postProcessKey)
+
+    if material.processType and material.processType != data.processType:
+        raise HTTPException(status_code=400, detail="所选材料与加工类型不匹配")
+    if machine.processType and machine.processType != data.processType:
+        raise HTTPException(status_code=400, detail="所选设备与加工类型不匹配")
+    if post.processType and post.processType != data.processType:
+        raise HTTPException(status_code=400, detail="所选后处理规则与加工类型不匹配")
+
+    weight = float(data.weight or 0)
+    volume = float(data.volume or 0)
+    if material.pricingMode == "VOLUME" and volume <= 0:
+        raise HTTPException(status_code=400, detail="当前材料按体积计价，请填写有效的体积")
+    if material.pricingMode != "VOLUME" and weight <= 0:
+        raise HTTPException(status_code=400, detail="当前材料按重量计价，请填写有效的重量")
+
+    hours_from_segments = (data.days or 0) * 24 + (data.hours or 0) + (data.minutes or 0) / 60
+    total_hours = data.totalHours if data.totalHours and data.totalHours > 0 else hours_from_segments
+    if total_hours <= 0:
+        raise HTTPException(status_code=400, detail="请填写打印时间（至少一个大于 0 的值）")
+
+    process_costs = _resolve_process_costs(settings, data.processType)
+    operator_hourly = process_costs["laborHourlyCost"] / (process_costs["machinesPerOperator"] or 1)
+    overhead_hourly = process_costs["overheadHourlyPerMachine"]
+    electricity_hourly = (machine.powerW or 0) / 1000 * (settings.electricityPrice or 0)
+
+    base_machine_hourly = machine.hourlyRate or 0
+    depreciation_hourly = _compute_machine_depreciation(machine)
+    machine_hourly = base_machine_hourly if base_machine_hourly > 0 else depreciation_hourly
+    operational_hourly = operator_hourly + overhead_hourly + electricity_hourly
+
+    inferred_all_in = (
+        machine.hourlyRateIncludesOperational is True
+        or (machine.hourlyRateIncludesOperational is None and base_machine_hourly > 0 and depreciation_hourly == 0)
+    )
+    should_add_operational = not inferred_all_in
+    effective_machine_hourly = machine_hourly + (operational_hourly if should_add_operational else 0)
+    machine_cost_per_part = total_hours * effective_machine_hourly
+
+    if material.pricingMode == "VOLUME":
+        material_cost_per_part = (volume / 1_000_000) * (material.pricePerCubicMeter or 0)
+    else:
+        material_cost_per_part = (weight / 1000) * (material.pricePerKg or 0)
+
+    total_post_minutes = (post.baseMinutes or 0) + (post.minutesPerGram or 0) * weight
+    post_labor_cost = process_costs["laborHourlyCost"] * total_post_minutes / 60
+    post_material_cost = (post.extraMaterialCostPerGram or 0) * weight
+    post_multiplier = post.costMultiplier or 1
+    post_cost_per_part = (post_labor_cost + post_material_cost) * post_multiplier
+
+    setup_fee = settings.setupFee
+    setup_cost_per_part = setup_fee / data.quantity if data.quantity > 0 else setup_fee
+
+    cost_sum_per_part = material_cost_per_part + machine_cost_per_part + post_cost_per_part + setup_cost_per_part
+    profit_margin = data.profitMargin if data.profitMargin is not None else settings.defaultProfitMargin
+    min_price_per_part = data.minPricePerPart if data.minPricePerPart is not None else settings.defaultMinPricePerPart
+    with_profit_per_part = cost_sum_per_part * (1 + profit_margin)
+    final_price_per_part = max(with_profit_per_part, min_price_per_part)
+    total_price = final_price_per_part * data.quantity
+
+    return CalcQuoteResponse(
+        processType=data.processType,
+        processLabel=data.processLabel,
+        quantity=data.quantity,
+        profitMargin=profit_margin,
+        minPricePerPart=min_price_per_part,
+        withProfitPerPart=with_profit_per_part,
+        finalPricePerPart=final_price_per_part,
+        totalPrice=total_price,
+        costSumPerPart=cost_sum_per_part,
+        materialCostPerPart=material_cost_per_part,
+        machineCostPerPart=machine_cost_per_part,
+        postCostPerPart=post_cost_per_part,
+        setupCostPerPart=setup_cost_per_part,
+        setupFee=setup_fee,
+        material=material,
+        machine=machine,
+        postProcess=post,
+        weight=weight,
+        volume=volume,
+        days=data.days,
+        hours=data.hours,
+        minutes=data.minutes,
+        totalHours=total_hours,
+        postLaborCost=post_labor_cost,
+        postMaterialCost=post_material_cost,
+        totalPostMinutes=total_post_minutes,
+        postMultiplier=post_multiplier,
+        machineHourlyRateUsed=effective_machine_hourly,
+        machineOperationalHourly=0 if inferred_all_in else operational_hourly,
+    )
+
 
 
 def reassign_quote_owners(old_username: str, new_username: str) -> int:
@@ -1370,6 +1575,19 @@ def delete_project(project_id: str, x_admin_session: Optional[str] = Header(None
     return {"deleted": project_id}
 
 
+@app.post("/api/calc-quote", response_model=CalcQuoteResponse)
+def calc_quote(
+    body: CalcQuoteRequest,
+    x_user_session: Optional[str] = Header(None),
+    x_admin_session: Optional[str] = Header(None),
+    x_session: Optional[str] = Header(None),
+):
+    """统一的报价计算接口，将所有金额计算移到后端。"""
+    require_authenticated(x_user_session, x_admin_session, x_session)
+    settings = load_settings()
+    return calculate_quote(body, settings)
+
+
 # ====== 报价记录：创建 / 查询 / 统计 ======
 
 
@@ -1401,16 +1619,64 @@ def create_quote_record(
     elif body.projectName:
         project_name = body.projectName
 
+    material_info = body.material or {}
+    machine_info = body.machine or {}
+    post_info = body.postProcess or {}
+
+    calc_request = CalcQuoteRequest(
+        processType=body.processType,
+        processLabel=body.processLabel,
+        materialVendor=str(material_info.get("vendor", "")),
+        materialName=str(material_info.get("name", "")),
+        materialPricingMode=material_info.get("pricingMode"),
+        machineVendor=str(machine_info.get("vendor", "")),
+        machineName=str(machine_info.get("name", "")),
+        postProcessKey=str(post_info.get("key") or post_info.get("name") or ""),
+        weight=body.weight,
+        volume=body.volume,
+        quantity=body.quantity,
+        totalHours=body.totalHours,
+        days=body.days or 0,
+        hours=body.hours or 0,
+        minutes=body.minutes or 0,
+        profitMargin=body.profitMargin,
+        minPricePerPart=body.minPricePerPart,
+    )
+
+    settings = load_settings()
+    calc_result = calculate_quote(calc_request, settings)
+
     existing = load_quote_records()
-    record_data = body.dict(exclude={"visibility", "adopted", "projectName"})
     record = QuoteRecord(
-        **record_data,
+        processType=calc_result.processType,
+        processLabel=calc_result.processLabel,
+        quantity=calc_result.quantity,
+        totalPrice=calc_result.totalPrice,
+        finalPricePerPart=calc_result.finalPricePerPart,
+        costSumPerPart=calc_result.costSumPerPart,
+        withProfitPerPart=calc_result.withProfitPerPart,
+        minPricePerPart=calc_result.minPricePerPart,
+        profitMargin=calc_result.profitMargin,
+        materialCostPerPart=calc_result.materialCostPerPart,
+        machineCostPerPart=calc_result.machineCostPerPart,
+        postCostPerPart=calc_result.postCostPerPart,
+        setupCostPerPart=calc_result.setupCostPerPart,
+        material=calc_result.material.dict(),
+        machine=calc_result.machine.dict(),
+        postProcess=calc_result.postProcess.dict(),
+        projectId=body.projectId,
+        projectName=project_name,
+        weight=calc_result.weight,
+        volume=calc_result.volume,
+        totalHours=calc_result.totalHours,
+        days=calc_result.days,
+        hours=calc_result.hours,
+        minutes=calc_result.minutes,
+        visibility=visibility,
+        adopted=bool(body.adopted) if is_admin else False,
         id=uuid4().hex,
         createdAt=datetime.utcnow().isoformat() + "Z",
         createdBy=session.get("username", "unknown"),
-        visibility=visibility,
-        adopted=bool(body.adopted) if is_admin else False,
-        projectName=project_name,
     )
     existing.append(record)
     save_quote_records(existing)


### PR DESCRIPTION
## Summary
- add a unified /api/calc-quote endpoint that mirrors the pricing formulas on the server
- recompute and persist quote records with backend-calculated costs to avoid client tampering
- update the frontend form to call the new API and render backend pricing results instead of local math

## Testing
- python -m compileall quote_api.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692425d167c483299bfbac47602fe0f2)