### PR TITLE
Expand backup and split labor costs

### DIFF
--- a/3d_quote.html
+++ b/3d_quote.html
@@ -2828,6 +2828,7 @@
             profitMargin: quote.profitMargin,
             materialCostPerPart: quote.materialCostPerPart,
             machineCostPerPart: quote.machineCostPerPart,
+            laborCostPerPart: quote.laborCostPerPart,
             postCostPerPart: quote.postCostPerPart,
             setupCostPerPart: quote.setupCostPerPart,
             material: quote.material,
@@ -3435,16 +3436,22 @@
       const inferredAllIn = hourlyRateIncludesOperational === true
         || (hourlyRateIncludesOperational == null && baseMachineHourly > 0 && depreciationHourly === 0);
       const shouldAddOperational = !inferredAllIn;
-      const effectiveMachineHourly = machineHourly + (shouldAddOperational ? operationalHourly : 0);
+      const printLaborHourly = shouldAddOperational ? operatorHourly : 0;
+      const machineOverheadHourly = shouldAddOperational ? (overheadHourly + electricityHourly) : 0;
+      const effectiveMachineHourly = machineHourly + machineOverheadHourly;
       const machineCostPerPart = totalHours * effectiveMachineHourly;
+      const printLaborCostPerPart = totalHours * printLaborHourly;
       const totalPostMinutes = (post.baseMinutes || 0) + (post.minutesPerGram || 0) * weight;
       const postLaborCost = (processCosts.laborHourlyCost || 0) * totalPostMinutes / 60;
       const postMaterialCost = (post.extraMaterialCostPerGram || 0) * weight;
       const postMultiplier = post.costMultiplier || 1;
-      const postCostPerPart = (postLaborCost + postMaterialCost) * postMultiplier;
+      const postLaborPortion = postLaborCost * postMultiplier;
+      const postMaterialPortion = postMaterialCost * postMultiplier;
+      const postCostPerPart = postLaborPortion + postMaterialPortion;
+      const laborCostPerPart = printLaborCostPerPart + postLaborPortion;
       const setupCostPerPart = quantity > 0 ? runtimeConfig.setupFee / quantity : runtimeConfig.setupFee;
 
-      const costSumPerPart = materialCostPerPart + machineCostPerPart + postCostPerPart + setupCostPerPart;
+      const costSumPerPart = materialCostPerPart + machineCostPerPart + laborCostPerPart + postMaterialPortion + setupCostPerPart;
       const withProfitPerPart = costSumPerPart * (1 + profitMargin);
       const finalPricePerPart = Math.max(withProfitPerPart, minPricePerPart);
       const totalPrice = finalPricePerPart * quantity;
@@ -3469,11 +3476,12 @@
         `   - 单件耗材：${materialUsageLabel} → 材料成本：${formatMoney(materialCostPerPart)}`,
         `▶ 设备：${machine.vendor} / ${machine.name}  ${machineHourlyLabel} 元/小时`,
         `   - 单件打印时间：${days} 天 ${hours} 小时 ${minutes} 分钟 ≈ ${totalHours.toFixed(2)} 小时`,
-        `   - 设备成本：${formatMoney(machineCostPerPart)}`,
-        `▶ 后处理：${post.name} → 单件后处理成本：${formatMoney(postCostPerPart)}（时间 ${totalPostMinutes.toFixed(2)} 分钟，人工 ${formatMoney(postLaborCost)}，材料 ${formatMoney(postMaterialCost)}，系数 x${postMultiplier.toFixed(2)}）`,
+        `   - 设备成本：${formatMoney(machineCostPerPart)}（含折旧/租赁 + 电费/杂项）`,
+        `   - 人工成本：${formatMoney(laborCostPerPart)}（打印人工 ${formatMoney(printLaborCostPerPart)} + 后处理人工 ${formatMoney(postLaborPortion)}）`,
+        `▶ 后处理：${post.name} → 单件后处理成本：${formatMoney(postCostPerPart)}（时间 ${totalPostMinutes.toFixed(2)} 分钟，人工 ${formatMoney(postLaborPortion)}，材料 ${formatMoney(postMaterialPortion)}，系数 x${postMultiplier.toFixed(2)}）`,
         `▶ 上机/调机费（订单）：${formatMoney(runtimeConfig.setupFee)}  分摊后每件：${formatMoney(setupCostPerPart)}`,
         "",
-        `▶ 单件成本小计：${formatMoney(costSumPerPart)}`,
+        `▶ 单件成本小计：${formatMoney(costSumPerPart)}（材料 + 设备 + 人工 + 后处理材料 + 上机费分摊）`,
         `▶ 利润率：${(profitMargin * 100).toFixed(0)}%`,
         `▶ 单件最低价：${formatMoney(minPricePerPart)}`,
         `▶ 含利润单价：${formatMoney(withProfitPerPart)}`,
@@ -3501,10 +3509,14 @@
         minPricePerPart,
         materialCostPerPart,
         machineCostPerPart,
+        laborCostPerPart,
         postCostPerPart,
         postMultiplier,
         postLaborCost,
+        postLaborPortion,
         postMaterialCost,
+        postMaterialPortion,
+        printLaborCostPerPart,
         totalPostMinutes,
         setupCostPerPart,
         machineHourlyRateUsed: effectiveMachineHourly,
@@ -3547,15 +3559,16 @@
         `设备：${lastQuote.machine.vendor} / ${lastQuote.machine.name}`,
         `设备小时成本：${formatMoney(lastQuote.machineHourlyRateUsed || lastQuote.machine.hourlyRate)} 元/小时`,
         `单件打印时间：${lastQuote.days} 天 ${lastQuote.hours} 小时 ${lastQuote.minutes} 分钟 ≈ ${lastQuote.totalHours.toFixed(2)} 小时`,
-        `设备成本（单件）：${formatMoney(lastQuote.machineCostPerPart)}`,
+        `设备成本（单件）：${formatMoney(lastQuote.machineCostPerPart)}（含折旧/租赁 + 电费/杂项）`,
+        `人工成本（单件）：${formatMoney(lastQuote.laborCostPerPart)}（打印人工 ${formatMoney(lastQuote.printLaborCostPerPart)} + 后处理人工 ${formatMoney(lastQuote.postLaborPortion)}）`,
         "",
         `后处理等级：${lastQuote.post.name}`,
-        `后处理成本（单件）：${formatMoney(lastQuote.postCostPerPart)}（时间 ${lastQuote.totalPostMinutes.toFixed(2)} 分钟，人工 ${formatMoney(lastQuote.postLaborCost)}, 材料 ${formatMoney(lastQuote.postMaterialCost)}, 系数 x${(lastQuote.postMultiplier || 1).toFixed(2)}）`,
+        `后处理成本（单件）：${formatMoney(lastQuote.postCostPerPart)}（时间 ${lastQuote.totalPostMinutes.toFixed(2)} 分钟，人工 ${formatMoney(lastQuote.postLaborPortion)}, 材料 ${formatMoney(lastQuote.postMaterialPortion)}, 系数 x${(lastQuote.postMultiplier || 1).toFixed(2)}）`,
         "",
         `上机/调机费（订单）：${formatMoney(runtimeConfig.setupFee)}`,
         `分摊后上机费（单件）：${formatMoney(lastQuote.setupCostPerPart)}`,
         "",
-        `单件成本小计：${formatMoney(lastQuote.costSumPerPart)}`,
+        `单件成本小计：${formatMoney(lastQuote.costSumPerPart)}（材料 + 设备 + 人工 + 后处理材料 + 上机费分摊）`,
         `利润率：${(lastQuote.profitMargin * 100).toFixed(0)}%`,
         `单件最低价：${formatMoney(lastQuote.minPricePerPart)}`,
         `含利润单价：${formatMoney(lastQuote.withProfitPerPart)}`,

--- a/quote_api.py
+++ b/quote_api.py
@@ -135,6 +135,7 @@ class QuoteRecordCreate(BaseModel):
     profitMargin: float
     materialCostPerPart: float
     machineCostPerPart: float
+    laborCostPerPart: float = 0.0
     postCostPerPart: float
     setupCostPerPart: float
     material: Dict
@@ -176,6 +177,7 @@ class FullBackup(BaseModel):
 
     createdAt: str
     settings: Settings
+    settingsBackup: Optional[Settings] = None
     accounts: List[Account]
     quotes: List[QuoteRecord]
     projects: List[Project]
@@ -437,6 +439,16 @@ def load_settings_backup() -> Settings:
         raise RuntimeError(f"无法读取备份：{exc}") from exc
 
 
+def try_load_settings_backup(default: Optional[Settings] = None) -> Optional[Settings]:
+    try:
+        return load_settings_backup()
+    except FileNotFoundError:
+        return default
+    except Exception as exc:
+        print("Failed to load settings backup:", exc)
+        return default
+
+
 def save_full_backup(payload: FullBackup):
     os.makedirs(os.path.dirname(FULL_BACKUP_FILE), exist_ok=True)
     with open(FULL_BACKUP_FILE, "w", encoding="utf-8") as f:
@@ -571,6 +583,7 @@ def load_quote_records() -> List[QuoteRecord]:
                     "visibility": item.get("visibility", "admin_only"),
                     "adopted": item.get("adopted", False),
                     "createdBy": item.get("createdBy") or item.get("username") or "unknown",
+                    "laborCostPerPart": item.get("laborCostPerPart", 0.0),
                 }
                 merged = {**item, **defaults}
                 if merged["visibility"] not in ("admin_only", "all_users", "owner_only"):
@@ -777,9 +790,12 @@ def backup_all(
     """将当前全部关键数据写入全量备份文件。"""
 
     require_admin(x_admin_session, x_user_session, x_session)
+    current_settings = load_settings()
+    backup_settings = try_load_settings_backup(current_settings)
     backup = FullBackup(
         createdAt=datetime.utcnow().isoformat() + "Z",
-        settings=load_settings(),
+        settings=current_settings,
+        settingsBackup=backup_settings,
         accounts=load_accounts(),
         quotes=load_quote_records(),
         projects=load_projects(),
@@ -806,7 +822,7 @@ def restore_full_backup(
 
     ensure_settings_valid(backup.settings)
     save_settings(backup.settings)
-    save_settings_backup(backup.settings)
+    save_settings_backup(backup.settingsBackup or backup.settings)
     save_quote_records(backup.quotes)
     save_projects(backup.projects)
     save_accounts(backup.accounts)


### PR DESCRIPTION
## Summary
- include settings backup content in full backup/restore to cover all persisted configuration files
- separate machine and labor costs in quote calculations and exports, persisting the new labor cost value

## Testing
- python -m compileall quote_api.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925937d924c8329abeed6a995342964)